### PR TITLE
Add support for attribute-value pairs in lazy loading blocked attributes

### DIFF
--- a/classes/class-images.php
+++ b/classes/class-images.php
@@ -104,6 +104,10 @@ class Visual_Portfolio_Images {
 
 	/**
 	 * Get blocked attributes to prevent our images lazy loading.
+	 *
+	 * Supports two formats:
+	 * 1. Attribute name only (e.g., 'data-skip-lazy')
+	 * 2. Attribute with value (e.g., 'fetchpriority="high"')
 	 */
 	public static function get_image_blocked_attributes() {
 		$blocked_attributes = array(
@@ -119,6 +123,7 @@ class Visual_Portfolio_Images {
 			'data-envira-src',
 			'fullurl',
 			'lazy-slider-img',
+			'fetchpriority="high"',
 		);
 
 		/**
@@ -316,7 +321,17 @@ class Visual_Portfolio_Images {
 		$blocked_attributes = self::get_image_blocked_attributes();
 
 		foreach ( $blocked_attributes as $attr ) {
-			if ( isset( $attributes[ $attr ] ) ) {
+			// Check if attribute contains a value (e.g., 'fetchpriority="high"').
+			if ( false !== strpos( $attr, '=' ) ) {
+				$parts      = explode( '=', $attr, 2 );
+				$attr_name  = trim( $parts[0] );
+				$attr_value = trim( $parts[1], '"' );
+
+				if ( isset( $attributes[ $attr_name ] ) && $attr_value === $attributes[ $attr_name ] ) {
+					return true;
+				}
+			} elseif ( isset( $attributes[ $attr ] ) ) {
+				// Handle attribute name only (backward compatibility).
 				return true;
 			}
 		}

--- a/tests/phpunit/unit/test-class-images.php
+++ b/tests/phpunit/unit/test-class-images.php
@@ -208,6 +208,60 @@ class ClassImages extends WP_UnitTestCase {
     }
 
     /**
+     * Skip lazy loading with attribute-value pairs.
+     */
+    public function test_lazy_loading_skip_attribute_with_value() {
+        // Enable lazy load in settings.
+        Visual_Portfolio_Images::$allow_wp_lazyload = true;
+        Visual_Portfolio_Images::$allow_vp_lazyload = true;
+
+        // Skip `fetchpriority="high"` attribute-value pair.
+        $image_string = '<img src="image.jpg" alt="Test Image" width="10" height="10" fetchpriority="high">';
+        $this->assertEquals(
+            $image_string,
+            Visual_Portfolio_Images::add_image_placeholders(
+                $image_string
+            ),
+            'Images with fetchpriority="high" should be skipped from lazy loading'
+        );
+
+        // Do NOT skip `fetchpriority="low"` - different value should be lazy loaded.
+        $placeholder  = Visual_Portfolio_Images::get_image_placeholder( 10, 10 );
+        $image_string = '<img src="image.jpg" alt="Test Image" width="10" height="10" fetchpriority="low">';
+        $lazy_string  = '<img src="' . $placeholder . '" alt="Test Image" width="10" height="10" fetchpriority="low" data-src="image.jpg" data-sizes="auto" loading="eager" class="vp-lazyload">';
+
+        $this->assertEquals(
+            $this->get_noscript_image( $image_string ) . $lazy_string,
+            Visual_Portfolio_Images::add_image_placeholders(
+                $image_string
+            ),
+            'Images with fetchpriority="low" should be lazy loaded'
+        );
+
+        // Do NOT skip `fetchpriority="auto"` - different value should be lazy loaded.
+        $image_string = '<img src="image.jpg" alt="Test Image" width="10" height="10" fetchpriority="auto">';
+        $lazy_string  = '<img src="' . $placeholder . '" alt="Test Image" width="10" height="10" fetchpriority="auto" data-src="image.jpg" data-sizes="auto" loading="eager" class="vp-lazyload">';
+
+        $this->assertEquals(
+            $this->get_noscript_image( $image_string ) . $lazy_string,
+            Visual_Portfolio_Images::add_image_placeholders(
+                $image_string
+            ),
+            'Images with fetchpriority="auto" should be lazy loaded'
+        );
+
+        // Verify backward compatibility - attribute name only (data-no-lazy) still works.
+        $image_string = '<img src="image.jpg" alt="Test Image" width="10" height="10" data-no-lazy="anything">';
+        $this->assertEquals(
+            $image_string,
+            Visual_Portfolio_Images::add_image_placeholders(
+                $image_string
+            ),
+            'Images with data-no-lazy attribute (any value) should be skipped'
+        );
+    }
+
+    /**
      * Prepare noscript image string.
      *
      * @param string $image_string - image string.


### PR DESCRIPTION
## Summary

Extends the lazy loading blocked attributes system to support both attribute names and attribute-value pairs. This allows more granular control over which images should skip lazy loading.

### Key Changes

- **Enhanced `get_image_blocked_attributes()`**: Now supports `attribute="value"` format (e.g., `fetchpriority="high"`)
- **Updated checking logic**: `should_skip_image_with_blocked_attributes()` now parses and validates attribute-value pairs
- **New default rule**: Added `fetchpriority="high"` to skip lazy loading for high-priority images
- **Backward compatible**: Existing attribute-only checks continue to work as before

### Examples

```php
// Old format (still supported)
'data-skip-lazy'  // Blocks any image with this attribute

// New format
'fetchpriority="high"'  // Only blocks when fetchpriority="high", not "low" or "auto"
```

### Test Coverage

Added comprehensive unit tests in `test_lazy_loading_skip_attribute_with_value()`:
- ✅ Images with `fetchpriority="high"` are skipped from lazy loading
- ✅ Images with `fetchpriority="low"` or `fetchpriority="auto"` are lazy loaded
- ✅ Backward compatibility with attribute-only blocking (e.g., `data-no-lazy`)
- ✅ Edge cases for different attribute values

## Files Changed

- [classes/class-images.php](classes/class-images.php) - Core implementation
- [tests/phpunit/unit/test-class-images.php](tests/phpunit/unit/test-class-images.php) - Unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)