### PR TITLE
Fix welcome screen redirect when Portfolio CPT is disabled

### DIFF
--- a/classes/class-welcome-screen.php
+++ b/classes/class-welcome-screen.php
@@ -164,6 +164,25 @@ class Visual_Portfolio_Welcome_Screen {
 	}
 
 	/**
+	 * Get welcome page URL.
+	 *
+	 * @return string
+	 */
+	public static function get_welcome_page_url() {
+		$welcome_page_url =
+		Visual_Portfolio_Custom_Post_Type::portfolio_post_type_is_registered() ?
+		'edit.php?post_type=portfolio' :
+		'admin.php';
+
+		return add_query_arg(
+			array(
+				'page' => 'visual-portfolio-welcome',
+			),
+			admin_url( $welcome_page_url )
+		);
+	}
+
+	/**
 	 * Redirect to Welcome page after activation.
 	 */
 	public function redirect_to_welcome_screen() {
@@ -182,7 +201,7 @@ class Visual_Portfolio_Welcome_Screen {
 		}
 
 		// Redirect to welcome page.
-		wp_safe_redirect( add_query_arg( array( 'page' => 'visual-portfolio-welcome' ), admin_url( Visual_Portfolio_Custom_Post_Type::get_menu_slug() ) ) );
+		wp_safe_redirect( self::get_welcome_page_url() );
 	}
 
 	/**

--- a/tests/phpunit/unit/test-class-welcome-screen.php
+++ b/tests/phpunit/unit/test-class-welcome-screen.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Tests for the welcome screen redirect URL.
+ *
+ * @package Visual Portfolio
+ */
+
+/**
+ * Welcome screen test case.
+ */
+class WelcomeScreenTest extends WP_UnitTestCase {
+	/**
+	 * Original general settings option.
+	 *
+	 * @var mixed
+	 */
+	protected $original_vp_general;
+
+	/**
+	 * Preserve option state.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_vp_general = get_option( 'vp_general' );
+	}
+
+	/**
+	 * Restore option state.
+	 */
+	public function tearDown(): void {
+		if ( false === $this->original_vp_general ) {
+			delete_option( 'vp_general' );
+		} else {
+			update_option( 'vp_general', $this->original_vp_general );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Use edit.php when Portfolio CPT is enabled.
+	 */
+	public function test_get_welcome_page_url_for_registered_portfolio_post_type() {
+		update_option(
+			'vp_general',
+			array(
+				'register_portfolio_post_type' => 'on',
+			)
+		);
+
+		$this->assertSame(
+			admin_url( 'edit.php?post_type=portfolio&page=visual-portfolio-welcome' ),
+			Visual_Portfolio_Welcome_Screen::get_welcome_page_url()
+		);
+	}
+
+	/**
+	 * Use admin.php when Portfolio CPT is disabled.
+	 */
+	public function test_get_welcome_page_url_for_unregistered_portfolio_post_type() {
+		update_option(
+			'vp_general',
+			array(
+				'register_portfolio_post_type' => 'off',
+			)
+		);
+
+		$this->assertSame(
+			admin_url( 'admin.php?page=visual-portfolio-welcome' ),
+			Visual_Portfolio_Welcome_Screen::get_welcome_page_url()
+		);
+	}
+}


### PR DESCRIPTION
## Summary
When the Portfolio custom post type is disabled, the activation redirect still needs to target the welcome/settings page through `admin.php`. This updates the welcome redirect to build the correct admin URL for both CPT-enabled and CPT-disabled modes.

## Changes
- add a dedicated welcome page URL helper in `Visual_Portfolio_Welcome_Screen`
- use `edit.php?post_type=portfolio` when the Portfolio CPT is registered
- use `admin.php?page=visual-portfolio-welcome` when the Portfolio CPT is disabled
- add unit tests for both URL variants

## Validation
- `php -l classes/class-welcome-screen.php`
- `php -l tests/phpunit/unit/test-class-welcome-screen.php`
- `npm run test:unit:php -- --filter WelcomeScreenTest`