### PR TITLE
Fix editor preview under Cloudflare Rocket Loader (inline VPData not cfasync-protected)

### DIFF
--- a/classes/class-preview.php
+++ b/classes/class-preview.php
@@ -249,10 +249,16 @@ class Visual_Portfolio_Preview {
 		// Disable the WP admin bar.
 		add_filter( 'show_admin_bar', '__return_false' );
 
-		// Avoid Cloudflare's Rocket Loader lazy load the editor iframe.
-		// TODO: we also need an additional filter, which is not available in the WP yet:
-		// https://github.com/WordPress/wordpress-develop/pull/1759 .
+		// Avoid Cloudflare's Rocket Loader lazy loading the editor iframe scripts.
+		//
+		// `script_loader_tag` only covers scripts with a `src`, while
+		// `wp_inline_script_attributes` (WP 5.7+) covers inline scripts such as
+		// the `VPData` / `vp_preview_post_data` localization. Both must be
+		// excluded, otherwise Rocket Loader defers the inline data and the
+		// portfolio scripts run before `VPData` exists, throwing
+		// "Cannot read properties of undefined (reading '__')".
 		add_filter( 'script_loader_tag', array( $this, 'rocket_loader_filter' ) );
+		add_filter( 'wp_inline_script_attributes', array( $this, 'rocket_loader_inline_filter' ) );
 
 		// Enqueue assets.
 		Visual_Portfolio_Assets::enqueue_script( 'iframe-resizer-content', 'assets/vendor/iframe-resizer/js/iframeResizer.contentWindow.min', array(), '4.3.11' );
@@ -318,6 +324,24 @@ class Visual_Portfolio_Preview {
 	 */
 	public function rocket_loader_filter( $tag ) {
 		return str_replace( '<script', '<script data-cfasync="false"', $tag );
+	}
+
+	/**
+	 * Disable rocket loader for inline scripts in preview.
+	 *
+	 * Inline localization scripts (e.g. `VPData`, `vp_preview_post_data`) are
+	 * printed via `wp_get_inline_script_tag()`, which does not go through the
+	 * `script_loader_tag` filter. Without this, Cloudflare's Rocket Loader
+	 * defers them and the portfolio scripts run before `VPData` is defined.
+	 *
+	 * @param array $attributes - inline script attributes.
+	 *
+	 * @return array
+	 */
+	public function rocket_loader_inline_filter( $attributes ) {
+		$attributes['data-cfasync'] = 'false';
+
+		return $attributes;
 	}
 }
 


### PR DESCRIPTION
## Problem

The Visual Portfolio block preview stays stuck on a spinner in the editor when **Cloudflare Rocket Loader** is active. Inside the preview iframe the console shows a cascade of `Uncaught TypeError: Cannot read properties of undefined` reading `__`, `settingsPopupGallery`, `screenSizes`, `parseGallery`, `vendors` — all fields of the global `VPData`. `main.js` fails at `const { __ } = VPData`.

## Root cause

`Visual_Portfolio_Preview::rocket_loader_filter()` adds `data-cfasync="false"` via the `script_loader_tag` filter, which only covers scripts **with a `src`**. The inline `wp_localize_script` output (`VPData`, `vp_preview_post_data`) is printed via `wp_get_inline_script_tag()` and was left unprotected, so Rocket Loader defers it. The protected VP `src` scripts then run **before** `VPData` exists → init aborts → endless spinner.

This is exactly the follow-up the existing `TODO` in `print_template()` was waiting for (referencing WordPress/wordpress-develop#1759, merged as the `wp_inline_script_attributes` filter in WP 5.7).

## Fix

Also exclude inline scripts from Rocket Loader in the preview via `wp_inline_script_attributes`, and drop the stale TODO.

## Testing

- Reproduced on a live site (Astra + Elementor + Cloudflare Rocket Loader): preview stuck, `VPData`-undefined errors in console.
- With the fix (verified via an equivalent Code Snippet that tags every preview `<script>` with `data-cfasync="false"`): scripts run in order, `VPData` defined first, block preview renders.
- Note: not all environments serve Rocket Loader (e.g. some CDN/bot paths disable it), so this must be tested against a site with Rocket Loader **enabled**.
- `composer run-script lint` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the preview iframe template only; no auth or data-model changes, and behavior matches the existing external-script Rocket Loader workaround.
> 
> **Overview**
> Fixes the block editor preview iframe staying on a spinner when **Cloudflare Rocket Loader** is on. Existing `script_loader_tag` handling only tagged external scripts with `data-cfasync="false"`; inline localization (`VPData`, `vp_preview_post_data`) was still deferred, so portfolio JS ran before globals existed.
> 
> The preview now hooks **`wp_inline_script_attributes`** (WP 5.7+) and sets `data-cfasync="false"` on inline scripts via new **`rocket_loader_inline_filter`**, alongside the existing external-script filter. Comments explain why both filters are required; the old TODO waiting on core is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f631c3b0022bd0705e0db1f17a0f4ed463d49e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->