### PR TITLE
fix(assets): guard missing layout in enqueue

### DIFF
--- a/classes/class-assets.php
+++ b/classes/class-assets.php
@@ -316,7 +316,7 @@ class Visual_Portfolio_Assets {
 		self::store_used_assets( 'visual-portfolio', true, 'script', 12 );
 
 		// Layout.
-		switch ( $options['layout'] ) {
+		switch ( $options['layout'] ?? '' ) {
 			case 'masonry':
 				self::store_used_assets( 'visual-portfolio-layout-masonry', true, 'script' );
 				self::store_used_assets( 'visual-portfolio-layout-masonry', true, 'style' );
@@ -344,7 +344,7 @@ class Visual_Portfolio_Assets {
 		self::store_used_assets( 'visual-portfolio-custom-scrollbar', true, 'style' );
 
 		// Items Style.
-		if ( $options['items_style'] ) {
+		if ( ! empty( $options['items_style'] ) ) {
 			$items_style_pref = '';
 
 			if ( 'default' !== $options['items_style'] ) {


### PR DESCRIPTION
PHPUnit sitemap tests create blocks without layout attrs; PHP 8+ treats undefined array keys as errors during asset enqueue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive checks in asset enqueue only; no auth, data, or rendering logic changes.
> 
> **Overview**
> **`Visual_Portfolio_Assets::enqueue()`** now tolerates incomplete portfolio options when deciding which scripts and styles to register.
> 
> The layout `switch` uses **`$options['layout'] ?? ''`** instead of reading `layout` directly, so a missing key skips layout-specific assets instead of raising an undefined array key notice. The items-style branch uses **`! empty( $options['items_style'] )`** instead of a bare truthiness check on a possibly undefined key.
> 
> Together these changes fix failures in **PHPUnit sitemap tests** where Visual Portfolio blocks are created **without layout attributes**, while leaving behavior unchanged when options are fully populated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90377ff31003f102996085b8a2c0ad2f57c033b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->