### PR TITLE
fix(assets): guard missing items_click_action in enqueue

### DIFF
--- a/classes/class-assets.php
+++ b/classes/class-assets.php
@@ -370,7 +370,7 @@ class Visual_Portfolio_Assets {
 		}
 
 		// Popup.
-		if ( 'popup_gallery' === $options['items_click_action'] ) {
+		if ( 'popup_gallery' === ( $options['items_click_action'] ?? '' ) ) {
 			self::enqueue_popup_assets();
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single defensive null-coalescing change in asset enqueue; no behavior change when the option is present.
> 
> **Overview**
> **Prevents PHP warnings** when portfolio asset enqueue runs with incomplete layout options (for example block attrs that only pass an `id`).
> 
> In `Visual_Portfolio_Assets::enqueue`, the popup-gallery check now uses `( $options['items_click_action'] ?? '' )` instead of reading `items_click_action` directly, consistent with how `layout` is already guarded in the same method. Popup scripts/styles are only loaded when the value is still `popup_gallery`; missing keys behave like a non-popup action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6815630d5869f0fb10498c7527fef0e1116f0944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->