### PR TITLE
fix(i18n): add the missing translator comments

### DIFF
--- a/classes/class-dashboard.php
+++ b/classes/class-dashboard.php
@@ -80,16 +80,17 @@ class Visual_Portfolio_Dashboard {
 		$num_posts        = wp_count_posts( 'portfolio' );
 		$published        = isset( $num_posts->publish ) ? (int) $num_posts->publish : 0;
 
-		$text = sprintf(
-			/* translators: %s: number of portfolio items */
-			_n(
-				'%s ' . $post_type_object->labels->singular_name, // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralSingle
-				'%s ' . $post_type_object->labels->name, // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralPlural
-				$published,
-				'visual-portfolio'
-			),
-			number_format_i18n( $published )
-		);
+		$label = 1 === $published
+			? $post_type_object->labels->singular_name
+			: $post_type_object->labels->name;
+
+		/*
+		 * The labels are already translated when the post type is registered, so
+		 * the count and the label are simply composed here. Passing a
+		 * concatenated string to _n() built the lookup key at runtime, which
+		 * never matches a catalogue entry.
+		 */
+		$text = sprintf( '%1$s %2$s', number_format_i18n( $published ), $label );
 
 		$edit_url = admin_url( 'edit.php?post_type=portfolio' );
 

--- a/gutenberg/block-saved/edit.js
+++ b/gutenberg/block-saved/edit.js
@@ -128,6 +128,7 @@ export default function BlockEdit(props) {
 					className="vpf-setup-wizard-saved"
 					icon={<ElementIcon width="20" height="20" />}
 					label={sprintf(
+						// translators: %s: plugin name.
 						__('Saved %s', 'visual-portfolio'),
 						pluginName
 					)}

--- a/gutenberg/components/gallery-control/index.js
+++ b/gutenberg/components/gallery-control/index.js
@@ -1324,6 +1324,7 @@ const SortableList = (props) => {
 				<span className="vpf-component-gallery-control-item-fullwidth vpf-component-gallery-control-item-pagination">
 					<span>
 						{sprintf(
+							// translators: %1$s: number of items shown, %2$s: total number of items.
 							__(
 								'Showing %1$s of %2$s media items',
 								'visual-portfolio'

--- a/gutenberg/custom-post-meta/video.js
+++ b/gutenberg/custom-post-meta/video.js
@@ -131,6 +131,7 @@ class VpVideoComponent extends Component {
 				<PanelRow>
 					<p className="description">
 						{sprintf(
+							// translators: %s: plugin name.
 							__(
 								'Video will be used in %s layouts only. Full list of supported links',
 								'visual-portfolio'

--- a/gutenberg/extensions/items-count-all.js
+++ b/gutenberg/extensions/items-count-all.js
@@ -64,6 +64,7 @@ function CountNotice(props) {
 				<li
 					dangerouslySetInnerHTML={{
 						__html: sprintf(
+							// translators: %d: maximum number of items per page.
 							__(
 								'Set the items per page to <u>less than %d</u>',
 								'visual-portfolio'


### PR DESCRIPTION
`make-pot` audits placeholders again now that `--skip-audit` is gone, and it reported five findings here.

### Missing translator comments

Four strings interpolated values with no explanation of what they are, so translators saw a bare `%s` with no way to tell a plugin name from a count. Each now carries a `translators:` comment, and the comments are verified to reach the generated `.pot`.

### A real defect in the dashboard glance item

`classes/class-dashboard.php` passed `'%s ' . $labels->singular_name` to `_n()`. The lookup key was therefore built at runtime and never matched a catalogue entry, so the string could not be translated in any locale — the `phpcs:ignore` comments on those lines were papering over it.

Post type labels are already translated when the type is registered, so the count and the label are now simply composed. The rendered output is identical: the failed lookup previously fell through to the untranslated msgid, which produced the same text.

`make-pot` is now clean for this plugin. Biome and PHPCS pass.
