### PR TITLE
fix(php): add the missing ABSPATH guards

### DIFF
--- a/gutenberg/utils/control-condition-check/index.php
+++ b/gutenberg/utils/control-condition-check/index.php
@@ -5,6 +5,10 @@
  * @package visual-portfolio
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Visual_Portfolio_Control_Condition_Check
  */

--- a/gutenberg/utils/control-get-value/index.php
+++ b/gutenberg/utils/control-get-value/index.php
@@ -1,9 +1,13 @@
 <?php
 /**
- * Control condition check.
+ * Get control value from block attributes.
  *
  * @package visual-portfolio
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Visual_Portfolio_Control_Get_Value

--- a/gutenberg/utils/controls-dynamic-css/index.php
+++ b/gutenberg/utils/controls-dynamic-css/index.php
@@ -5,6 +5,10 @@
  * @package visual-portfolio
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Visual_Portfolio_Controls_Dynamic_CSS
  */


### PR DESCRIPTION
## What

Adds the `if ( ! defined( 'ABSPATH' ) ) { exit; }` guard to three helpers under `gutenberg/utils/`:

- `control-condition-check/index.php`
- `control-get-value/index.php`
- `controls-dynamic-css/index.php`

Placement matches `gutenberg/utils/encode-decode/index.php` — directly after the file docblock.

Also fixes the docblock in `control-get-value/index.php`, which was copy-pasted from its sibling and read "Control condition check."

## Why

`.claude/rules/php.md` requires the guard on every PHP file, and every other PHP file in the plugin already has it. These three were reachable by direct request. Impact is low in practice — each file only declares a class, so nothing executes on include — but the inconsistency is worth closing.

## Notes for the reviewer

**A fourth file is still missing the guard.** `gutenberg/utils/convert-legacy-attributes/index.php` has no ABSPATH check either. It's left out of this PR to keep the diff to the reported scope; happy to fold it in here or send it separately.

**`@package` tags deliberately untouched.** The rule text describes a `visual-portfolio/<area>` suffix, but the codebase doesn't follow that:

| Tag | Count |
|---|---|
| `visual-portfolio` (plain) | 112 |
| `visual-portfolio/<area>` (all suffixes) | ~20, across 10 one-off suffixes |

All three files already used the plain majority form, so matching real practice meant changing nothing. The rule and the codebase disagree here — if the suffix is genuinely wanted, that's a separate sweep; otherwise the rule wording should be relaxed.

## Testing

`npm run lint:php` could not run as written: wp-env failed to start because this worktree's assigned ports (8968/8969) were held by an unrelated project's environment. The identical check was run on the host instead — `npm run lint:php` is just `phpcs --standard=phpcs.xml.dist` inside the container:

```
vendor/bin/phpcs --standard=phpcs.xml.dist --no-cache
```

128 files, 0 errors, 0 warnings, with all three edited files confirmed processed. Same ruleset and same `testVersion 7.2-` compatibility config; the only difference is host PHP 8.3 running the sniffer, which affects the analyzer runtime rather than the rules applied. The pre-commit hook also ran `composer run-script lint` over the three staged files and passed. CI will give the container-side confirmation.