### PR TITLE
fix(loop): harden the experimental gallery loop blocks

### DIFF
--- a/classes/class-assets.php
+++ b/classes/class-assets.php
@@ -736,6 +736,8 @@ class Visual_Portfolio_Assets {
 				// translators: %s - plugin name.
 				'couldnt_retrieve_vp'  => sprintf( __( 'Couldn\'t retrieve %s ID.', 'visual-portfolio' ), visual_portfolio()->plugin_name ),
 
+				'loop_items_updated'   => esc_html__( 'Gallery items updated.', 'visual-portfolio' ),
+
 				'pswp_close'           => esc_attr__( 'Close (Esc)', 'visual-portfolio' ),
 				'pswp_share'           => esc_attr__( 'Share', 'visual-portfolio' ),
 				'pswp_fs'              => esc_attr__( 'Toggle fullscreen', 'visual-portfolio' ),
@@ -945,6 +947,58 @@ class Visual_Portfolio_Assets {
 	}
 
 	/**
+	 * Find gallery blocks inside the given blocks tree.
+	 *
+	 * @param array $blocks - blocks array.
+	 *
+	 * @return array
+	 */
+	private static function find_gallery_blocks( $blocks ) {
+		$found = array();
+
+		if ( ! is_array( $blocks ) ) {
+			return $found;
+		}
+
+		foreach ( $blocks as $block ) {
+			if ( isset( $block['blockName'] ) && 'visual-portfolio/block' === $block['blockName'] ) {
+				$found[] = $block;
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = array_merge( $found, self::find_gallery_blocks( $block['innerBlocks'] ) );
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Enqueue assets used by a Gallery Loop block.
+	 *
+	 * A gallery inside a loop takes its content source from the loop context, so
+	 * its own attributes are not enough to resolve which assets it needs.
+	 *
+	 * @param array $block - loop block data.
+	 */
+	private static function enqueue_loop_block( $block ) {
+		$loop_options = Visual_Portfolio_Convert_Attributes::modern_to_legacy( $block['attrs'] ?? array(), true );
+
+		if ( empty( $loop_options ) ) {
+			return;
+		}
+
+		foreach ( self::find_gallery_blocks( $block['innerBlocks'] ?? array() ) as $gallery ) {
+			if ( ! isset( $gallery['attrs']['block_id'] ) ) {
+				continue;
+			}
+
+			// The loop query wins over whatever the gallery was configured with.
+			self::enqueue( array_merge( $gallery['attrs'], $loop_options ) );
+		}
+	}
+
+	/**
 	 * Parse blocks from content.
 	 *
 	 * @param array $blocks - blocks array.
@@ -963,6 +1017,13 @@ class Visual_Portfolio_Assets {
 				isset( $block['attrs']['block_id'] )
 			) {
 				self::enqueue( $block['attrs'] );
+
+				// Gallery Loop block.
+			} elseif (
+				isset( $block['blockName'] ) &&
+				'visual-portfolio/loop' === $block['blockName']
+			) {
+				self::enqueue_loop_block( $block );
 
 				// Saved block.
 			} elseif (

--- a/classes/class-assets.php
+++ b/classes/class-assets.php
@@ -976,25 +976,23 @@ class Visual_Portfolio_Assets {
 	/**
 	 * Enqueue assets used by a Gallery Loop block.
 	 *
-	 * A gallery inside a loop takes its content source from the loop context, so
-	 * its own attributes are not enough to resolve which assets it needs.
+	 * A gallery inside a loop has no `content_source` of its own - it comes from
+	 * the loop context at render time - so it is skipped by the check in
+	 * `maybe_parse_blocks_from_content()` and has to be picked up here.
+	 *
+	 * The loop query itself is not needed: `enqueue()` resolves assets from the
+	 * layout, skin, pagination, filter and click action, all of which live on the
+	 * gallery block.
 	 *
 	 * @param array $block - loop block data.
 	 */
 	private static function enqueue_loop_block( $block ) {
-		$loop_options = Visual_Portfolio_Convert_Attributes::modern_to_legacy( $block['attrs'] ?? array(), true );
-
-		if ( empty( $loop_options ) ) {
-			return;
-		}
-
 		foreach ( self::find_gallery_blocks( $block['innerBlocks'] ?? array() ) as $gallery ) {
 			if ( ! isset( $gallery['attrs']['block_id'] ) ) {
 				continue;
 			}
 
-			// The loop query wins over whatever the gallery was configured with.
-			self::enqueue( array_merge( $gallery['attrs'], $loop_options ) );
+			self::enqueue( $gallery['attrs'] );
 		}
 	}
 

--- a/classes/class-get-portfolio.php
+++ b/classes/class-get-portfolio.php
@@ -2211,7 +2211,7 @@ class Visual_Portfolio_Get {
 	 * @return array sort slug => label.
 	 */
 	public static function get_sort_items( $vp_options = array() ) {
-		return apply_filters(
+		$items = apply_filters(
 			'vpf_extend_sort_items',
 			array(
 				''           => __( 'Default sorting', 'visual-portfolio' ),
@@ -2221,6 +2221,16 @@ class Visual_Portfolio_Get {
 				'title_desc' => __( 'Sort by title (Z-A)', 'visual-portfolio' ),
 			),
 			$vp_options
+		);
+
+		// This filter used to receive escaped labels, so callbacks written
+		// against that may return escaped ones. Decoding keeps a single level of
+		// escaping either way, since every caller escapes on output.
+		return array_map(
+			function ( $label ) {
+				return is_string( $label ) ? html_entity_decode( $label, ENT_QUOTES, get_bloginfo( 'charset' ) ) : $label;
+			},
+			$items
 		);
 	}
 

--- a/classes/class-get-portfolio.php
+++ b/classes/class-get-portfolio.php
@@ -1178,9 +1178,64 @@ class Visual_Portfolio_Get {
 	 *
 	 * @return int
 	 */
-	private static function get_current_page_number() {
+	public static function get_current_page_number() {
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.NonceVerification
 		return max( 1, isset( $_GET['vp_page'] ) ? Visual_Portfolio_Security::sanitize_number( $_GET['vp_page'] ) : 1 );
+	}
+
+	/**
+	 * Calculate how many pages the given query produces.
+	 *
+	 * The active filter is taken from the request by `get_query_params()`, so
+	 * the result already accounts for `?vp_filter`.
+	 *
+	 * @param array $options - block options in the legacy format.
+	 *
+	 * @return int
+	 */
+	public static function calculate_max_pages( $options ) {
+		$options = Visual_Portfolio_Security::validate_calculate_max_pages_params( $options );
+
+		$content_source = $options['content_source'] ?? '';
+
+		// `get_query_params()` expects a populated set of options, and there is
+		// nothing to count without a source anyway.
+		if ( ! $content_source ) {
+			return 1;
+		}
+
+		$items_count = (int) ( $options['items_count'] ?? 0 );
+
+		// A count of `0` divides by zero further down. A negative count means
+		// "all items" and is handled by `get_query_params()`.
+		if ( 0 === $items_count ) {
+			$items_count = 6;
+		}
+
+		$options['items_count'] = $items_count;
+
+		$query_opts = self::get_query_params( $options, false );
+
+		if ( isset( $query_opts['max_num_pages'] ) ) {
+			return max( 1, (int) $query_opts['max_num_pages'] );
+		}
+
+		switch ( $content_source ) {
+			case 'post-based':
+				$query     = new WP_Query( $query_opts );
+				$max_pages = $query->max_num_pages ? $query->max_num_pages : ceil( $query->found_posts / $items_count );
+
+				return max( 1, (int) $max_pages );
+
+			case 'images':
+			case 'social-stream':
+				$images_count = count( $query_opts['images'] ?? array() );
+
+				return max( 1, (int) ceil( $images_count / $items_count ) );
+
+			default:
+				return 1;
+		}
 	}
 
 	/**
@@ -2136,6 +2191,62 @@ class Visual_Portfolio_Get {
 	}
 
 	/**
+	 * Get current sort slug
+	 * ?vp_sort=date_desc
+	 *
+	 * @return string
+	 */
+	public static function get_current_sort() {
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+		return isset( $_GET['vp_sort'] ) ? sanitize_text_field( wp_unslash( $_GET['vp_sort'] ) ) : '';
+	}
+
+	/**
+	 * Get available sort items.
+	 *
+	 * Labels are not escaped, escape them on output.
+	 *
+	 * @param array $vp_options current vp_list options.
+	 *
+	 * @return array sort slug => label.
+	 */
+	public static function get_sort_items( $vp_options = array() ) {
+		return apply_filters(
+			'vpf_extend_sort_items',
+			array(
+				''           => __( 'Default sorting', 'visual-portfolio' ),
+				'date_desc'  => __( 'Sort by date (newest)', 'visual-portfolio' ),
+				'date'       => __( 'Sort by date (oldest)', 'visual-portfolio' ),
+				'title'      => __( 'Sort by title (A-Z)', 'visual-portfolio' ),
+				'title_desc' => __( 'Sort by title (Z-A)', 'visual-portfolio' ),
+			),
+			$vp_options
+		);
+	}
+
+	/**
+	 * Get URL of the given sort item.
+	 *
+	 * @param string $slug sort slug.
+	 * @param array  $vp_options current vp_list options.
+	 *
+	 * @return string
+	 */
+	public static function get_sort_item_url( $slug, $vp_options = array() ) {
+		return apply_filters(
+			'vpf_extend_sort_item_url',
+			self::get_pagenum_link(
+				array(
+					'vp_sort' => rawurlencode( $slug ),
+					'vp_page' => 1,
+				)
+			),
+			$slug,
+			$vp_options
+		);
+	}
+
+	/**
 	 * Print sort
 	 *
 	 * @param array $vp_options current vp_list options.
@@ -2148,38 +2259,12 @@ class Visual_Portfolio_Get {
 		$terms = array();
 
 		// Get active item.
-		$active_item = false;
+		$active_item = self::get_current_sort();
 
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['vp_sort'] ) ) {
-            // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$active_item = sanitize_text_field( wp_unslash( $_GET['vp_sort'] ) );
-		}
-
-		$sort_items = apply_filters(
-			'vpf_extend_sort_items',
-			array(
-				''           => esc_html__( 'Default sorting', 'visual-portfolio' ),
-				'date_desc'  => esc_html__( 'Sort by date (newest)', 'visual-portfolio' ),
-				'date'       => esc_html__( 'Sort by date (oldest)', 'visual-portfolio' ),
-				'title'      => esc_html__( 'Sort by title (A-Z)', 'visual-portfolio' ),
-				'title_desc' => esc_html__( 'Sort by title (Z-A)', 'visual-portfolio' ),
-			),
-			$vp_options
-		);
+		$sort_items = self::get_sort_items( $vp_options );
 
 		foreach ( $sort_items as $slug => $label ) {
-			$url = apply_filters(
-				'vpf_extend_sort_item_url',
-				self::get_pagenum_link(
-					array(
-						'vp_sort' => rawurlencode( $slug ),
-						'vp_page' => 1,
-					)
-				),
-				$slug,
-				$vp_options
-			);
+			$url = self::get_sort_item_url( $slug, $vp_options );
 
 			$is_active = ! $active_item && ! $slug ? true : $active_item === $slug;
 

--- a/classes/class-rest.php
+++ b/classes/class-rest.php
@@ -84,15 +84,17 @@ class Visual_Portfolio_Rest extends WP_REST_Controller {
 			)
 		);
 
-		register_rest_route(
-			$namespace,
-			'/get-max-pages/',
-			array(
-				'methods'             => WP_REST_Server::READABLE . ', ' . WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'get_max_pages' ),
-				'permission_callback' => array( $this, 'get_max_pages_permission' ),
-			)
+		// Get max pages.
+		$max_pages_route = array(
+			'methods'             => array( WP_REST_Server::READABLE, WP_REST_Server::CREATABLE ),
+			'callback'            => array( $this, 'get_max_pages' ),
+			'permission_callback' => array( $this, 'get_max_pages_permission' ),
 		);
+
+		register_rest_route( $namespace, '/get_max_pages/', $max_pages_route );
+
+		// Deprecated alias, the other routes in this namespace use snake_case.
+		register_rest_route( $namespace, '/get-max-pages/', $max_pages_route );
 	}
 
 	/**
@@ -105,64 +107,15 @@ class Visual_Portfolio_Rest extends WP_REST_Controller {
 	}
 
 	/**
-	 * Calculate max pages based on query attributes.
+	 * Calculate max pages based on modern query attributes.
 	 *
-	 * @param array $params Full query data.
+	 * @param array $params Full query data in the modern format.
 	 * @return int $max_pages Response max pages data.
 	 */
 	public function calculate_max_pages( $params ) {
-		// Convert modern params to legacy format.
-		$params = Visual_Portfolio_Convert_Attributes::modern_to_legacy( $params );
-
-		$params = Visual_Portfolio_Security::validate_calculate_max_pages_params( $params );
-
-		$content_source = $params['content_source'] ?? '';
-		$items_count    = (int) ( $params['items_count'] ?? 0 );
-
-		// Add filter from GET if not in params.
-		if ( empty( $params['vp_filter'] ) && ! empty( $_GET['vp_filter'] ) ) {
-			$params['vp_filter'] = sanitize_text_field( wp_unslash( $_GET['vp_filter'] ) );
-		}
-
-		// Decode JSON images if needed.
-		if ( 'images' === $content_source &&
-			is_string( $params['images'] ?? '' ) &&
-			0 === strpos( $params['images'], '[' ) ) {
-			$decoded = json_decode( $params['images'], true );
-			if ( JSON_ERROR_NONE === json_last_error() ) {
-				$params['images'] = $decoded;
-			}
-		}
-
-		// Get query options and calculate max pages.
-		$options = array_merge(
-			array(
-				'content_source' => $content_source,
-				'items_count'    => $items_count,
-			),
-			$params
+		return Visual_Portfolio_Get::calculate_max_pages(
+			Visual_Portfolio_Convert_Attributes::modern_to_legacy( $params )
 		);
-
-		$query_opts = Visual_Portfolio_Get::get_query_params( $options, false );
-
-		if ( isset( $query_opts['max_num_pages'] ) ) {
-			return max( 1, $query_opts['max_num_pages'] );
-		}
-
-		switch ( $content_source ) {
-			case 'post-based':
-				$query     = new WP_Query( $query_opts );
-				$max_pages = $query->max_num_pages ? $query->max_num_pages : ceil( $query->found_posts / $items_count );
-				return max( 1, $max_pages );
-
-			case 'images':
-			case 'social-stream':
-				$images_count = count( $query_opts['images'] ?? array() );
-				return max( 1, ceil( $images_count / $items_count ) );
-
-			default:
-				return 1;
-		}
 	}
 
 	/**
@@ -194,6 +147,30 @@ class Visual_Portfolio_Rest extends WP_REST_Controller {
 	}
 
 	/**
+	 * Build the "All" filter item.
+	 *
+	 * @param int  $post_id - post the filter is displayed on.
+	 * @param bool $active - whether no filter is applied.
+	 *
+	 * @return array
+	 */
+	private function get_all_filter_item( $post_id, $active = true ) {
+		$url = get_permalink( $post_id );
+
+		return array(
+			'filter'      => '*',
+			'label'       => esc_html__( 'All', 'visual-portfolio' ),
+			'description' => '',
+			'count'       => false,
+			'active'      => $active,
+			'url'         => $url ? $url : home_url(),
+			'taxonomy'    => '',
+			'id'          => 0,
+			'parent'      => 0,
+		);
+	}
+
+	/**
 	 * Get filter items.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -213,7 +190,7 @@ class Visual_Portfolio_Rest extends WP_REST_Controller {
 
 		$params         = Visual_Portfolio_Convert_Attributes::modern_to_legacy( $params );
 		$content_source = $params['content_source'] ?? false;
-		$post_id        = $request->get_param( 'post_id' );
+		$post_id        = absint( $request->get_param( 'post_id' ) );
 
 		if ( ! $content_source ) {
 			return $this->error(
@@ -223,42 +200,43 @@ class Visual_Portfolio_Rest extends WP_REST_Controller {
 		}
 
 		// Define allowed parameters for each content source.
-		$source_configs = array(
-			'post-based' => array(
-				'posts_source',
-				'post_types_set',
-				'posts_taxonomies',
-				'posts_taxonomies_relation',
-				'posts_order_by',
-				'posts_order_direction',
+		$source_configs = apply_filters(
+			'vpf_rest_filter_items_source_configs',
+			array(
+				'post-based' => array(
+					'posts_source',
+					'post_types_set',
+					'posts_taxonomies',
+					'posts_taxonomies_relation',
+					'posts_order_by',
+					'posts_order_direction',
+				),
+				'images' => array(
+					'images',
+					'images_titles_source',
+					'images_descriptions_source',
+					'images_order_by',
+					'images_order_direction',
+					'items_count',
+				),
 			),
-			'images' => array(
-				'images',
-				'images_titles_source',
-				'images_descriptions_source',
-				'images_order_by',
-				'images_order_direction',
-				'items_count',
-			),
+			$params
 		);
 
-		// Build options array.
-		$options = array(
-			'content_source' => $content_source,
-		);
-
-		if ( isset( $source_configs[ $content_source ] ) ) {
-			// Filter and add only relevant parameters.
-			$allowed_keys    = array_flip( $source_configs[ $content_source ] );
-			$filtered_params = array_intersect_key( $params, $allowed_keys );
-			$options         = array_merge( $options, $filtered_params );
-		} else {
-			return $this->error(
-				'invalid_content_source',
-				/* translators: %s: Invalid content source type */
-				sprintf( esc_html__( 'Invalid content source: %s', 'visual-portfolio' ), esc_html( $content_source ) )
-			);
+		// Sources that are not filterable have no terms to offer, but they are
+		// not an error - the block simply shows the "All" item.
+		if ( ! isset( $source_configs[ $content_source ] ) ) {
+			return $this->success( array( $this->get_all_filter_item( $post_id ) ) );
 		}
+
+		// Filter and add only relevant parameters.
+		$allowed_keys    = array_flip( $source_configs[ $content_source ] );
+		$filtered_params = array_intersect_key( $params, $allowed_keys );
+
+		$options = array_merge(
+			array( 'content_source' => $content_source ),
+			$filtered_params
+		);
 
 		// Get query parameters.
 		$query_opts = Visual_Portfolio_Get::get_query_params( $options, true );
@@ -302,17 +280,7 @@ class Visual_Portfolio_Rest extends WP_REST_Controller {
 		$response = array();
 
 		// Add 'All' item.
-		$response[] = array(
-			'filter'      => '*',
-			'label'       => esc_html__( 'All', 'visual-portfolio' ),
-			'description' => '',
-			'count'       => false,
-			'active'      => ! $active_item,
-			'url'         => $get_filter_url(),
-			'taxonomy'    => '',
-			'id'          => 0,
-			'parent'      => 0,
-		);
+		$response[] = $this->get_all_filter_item( $post_id, ! $active_item );
 
 		// Add term items.
 		if ( ! empty( $term_items['terms'] ) ) {

--- a/classes/class-rest.php
+++ b/classes/class-rest.php
@@ -226,7 +226,14 @@ class Visual_Portfolio_Rest extends WP_REST_Controller {
 		// Sources that are not filterable have no terms to offer, but they are
 		// not an error - the block simply shows the "All" item.
 		if ( ! isset( $source_configs[ $content_source ] ) ) {
-			return $this->success( array( $this->get_all_filter_item( $post_id ) ) );
+			return $this->success(
+				array(
+					$this->get_all_filter_item(
+						$post_id,
+						! Visual_Portfolio_Get::get_filter_active_item( array() )
+					),
+				)
+			);
 		}
 
 		// Filter and add only relevant parameters.

--- a/gutenberg/block/edit.js
+++ b/gutenberg/block/edit.js
@@ -78,11 +78,11 @@ function renderControls(props, isChildOfLoop) {
 
 						return (
 							<ControlsRender
+								{...props}
 								key={name}
 								category={name}
 								categoryInitialOpen={categoryInitialOpen}
 								controls={controls}
-								{...props}
 							/>
 						);
 					})

--- a/gutenberg/block/edit.js
+++ b/gutenberg/block/edit.js
@@ -4,6 +4,7 @@ import { useEffect } from '@wordpress/element';
 import ControlsRender from '../components/controls-render';
 import IframePreview from '../components/iframe-preview';
 import SetupWizard from '../components/setup-wizard';
+import { LOOP_GENERAL_CONTROLS, pickControls } from '../utils/loop-controls';
 
 const {
 	plugin_url: pluginUrl,
@@ -15,10 +16,11 @@ function filterControlCategories(categories, isChildOfLoop) {
 		return categories;
 	}
 
-	// Categories to remove when block is child of Loop
+	// Categories to remove when block is child of Loop. `content-source-general`
+	// stays: the loop only takes over the query settings from it, the rendering
+	// ones are still applied by this block.
 	const categoriesToRemove = [
 		'content-source',
-		'content-source-general',
 		'content-source-images',
 		'content-source-post-based',
 		'content-source-taxonomies',
@@ -68,11 +70,18 @@ function renderControls(props, isChildOfLoop) {
 						const categoryInitialOpen =
 							isChildOfLoop && name === 'layout-elements';
 
+						// The loop owns the query settings of this category.
+						const controls =
+							isChildOfLoop && 'content-source-general' === name
+								? pickControls(LOOP_GENERAL_CONTROLS, true)
+								: undefined;
+
 						return (
 							<ControlsRender
 								key={name}
 								category={name}
 								categoryInitialOpen={categoryInitialOpen}
+								controls={controls}
 								{...props}
 							/>
 						);

--- a/gutenberg/blocks/filter-by-category-item/block.json
+++ b/gutenberg/blocks/filter-by-category-item/block.json
@@ -7,7 +7,7 @@
 	"description": "Displays individual filter item. Block is experimental and will change in future releases. Please use with caution.",
 	"ancestor": ["visual-portfolio/filter-by-category"],
 	"textdomain": "visual-portfolio",
-	"usesContext": ["visual-portfolio-filter-by-category/showCount"],
+	"usesContext": ["vp/queryType", "vp/showCount"],
 	"supports": {
 		"lock": true,
 		"html": false,
@@ -55,7 +55,7 @@
 	"attributes": {
 		"lock": {
 			"type": "object",
-			"default": { "move": true, "remove": true }
+			"default": { "move": false, "remove": true }
 		},
 		"text": { "type": "string", "default": "" },
 		"filter": { "type": "string", "default": "*" },

--- a/gutenberg/blocks/filter-by-category-item/edit.js
+++ b/gutenberg/blocks/filter-by-category-item/edit.js
@@ -6,8 +6,7 @@ export default function BlockEdit({ attributes, setAttributes, context }) {
 	const { text, isActive, isAll, count } = attributes;
 
 	// Get context values with fallbacks
-	const showCount =
-		context?.['visual-portfolio-filter-by-category/showCount'] || false;
+	const showCount = context?.['vp/showCount'] || false;
 
 	const blockProps = useBlockProps({
 		className: classnames('vp-block-filter-by-category-item', {

--- a/gutenberg/blocks/filter-by-category-item/index.js
+++ b/gutenberg/blocks/filter-by-category-item/index.js
@@ -5,7 +5,7 @@ import metadata from './block.json';
 import BlockEdit from './edit';
 import BlockSave from './save';
 
-registerBlockType('vp/filter-by-category-item', {
+registerBlockType(metadata.name, {
 	...metadata,
 	icon: {
 		foreground: '#2540CC',

--- a/gutenberg/blocks/filter-by-category-item/index.php
+++ b/gutenberg/blocks/filter-by-category-item/index.php
@@ -55,8 +55,11 @@ class Visual_Portfolio_Block_Filter_By_Category_Item {
 
 		$taxonomy_id = isset( $attributes['taxonomyId'] ) ? (int) $attributes['taxonomyId'] : 0;
 
-		if ( 'posts' === $query_type && $taxonomy_id ) {
-			$term = get_term( $taxonomy_id );
+		// Posts are filtered by `taxonomy:slug`. A bare slug is silently ignored
+		// by the query, so an item without a resolvable term renders nothing
+		// rather than a link that looks like a filter and does not filter.
+		if ( 'posts' === $query_type ) {
+			$term = $taxonomy_id ? get_term( $taxonomy_id ) : false;
 
 			if ( ! $term || is_wp_error( $term ) ) {
 				return false;

--- a/gutenberg/blocks/filter-by-category-item/index.php
+++ b/gutenberg/blocks/filter-by-category-item/index.php
@@ -33,6 +33,42 @@ class Visual_Portfolio_Block_Filter_By_Category_Item {
 	}
 
 	/**
+	 * Get the `vp_filter` query value for the given item.
+	 *
+	 * Posts are filtered by `taxonomy:slug`, media and social items by the
+	 * category slug alone. The value is built the same way as
+	 * `Visual_Portfolio_Get::get_posts_terms()` builds it, so URLs stay
+	 * identical to the ones the legacy filter produces.
+	 *
+	 * @param array  $attributes - block attributes.
+	 * @param string $query_type - content source of the parent loop.
+	 *
+	 * @return string|false Query value, or false when the term is gone.
+	 */
+	private static function get_filter_value( $attributes, $query_type ) {
+		$filter = $attributes['filter'] ?? '*';
+
+		// The "All" item resets the filter.
+		if ( '*' === $filter ) {
+			return '';
+		}
+
+		$taxonomy_id = isset( $attributes['taxonomyId'] ) ? (int) $attributes['taxonomyId'] : 0;
+
+		if ( 'posts' === $query_type && $taxonomy_id ) {
+			$term = get_term( $taxonomy_id );
+
+			if ( ! $term || is_wp_error( $term ) ) {
+				return false;
+			}
+
+			return rawurlencode( $term->taxonomy . ':' ) . $term->slug;
+		}
+
+		return rawurlencode( $filter );
+	}
+
+	/**
 	 * Block output
 	 *
 	 * @param array  $attributes - block attributes.
@@ -43,100 +79,83 @@ class Visual_Portfolio_Block_Filter_By_Category_Item {
 	 */
 	public function block_render( $attributes, $content, $block ) {
 		// Extract attributes with defaults.
-		$filter    = isset( $attributes['filter'] ) ? $attributes['filter'] : '*';
-		$count     = isset( $attributes['count'] ) ? intval( $attributes['count'] ) : 0;
-		$is_all    = isset( $attributes['isAll'] ) ? $attributes['isAll'] : false;
-		$text      = isset( $attributes['text'] ) ? $attributes['text'] : '';
-		$url       = isset( $attributes['url'] ) ? $attributes['url'] : '';
-		$is_active = isset( $attributes['isActive'] ) ? $attributes['isActive'] : false;
+		$filter = $attributes['filter'] ?? '*';
+		$count  = isset( $attributes['count'] ) ? (int) $attributes['count'] : 0;
+		$is_all = '*' === $filter;
+		$text   = $attributes['text'] ?? '';
 
-		// Get showCount from parent block context.
-		$show_count = false;
-		if ( isset( $block->context['visual-portfolio-filter-by-category/showCount'] ) ) {
-			$show_count = $block->context['visual-portfolio-filter-by-category/showCount'];
+		// Get showCount from parent block context. The parent also provides it
+		// under its old, longer key, which is deprecated but still consumable.
+		$show_count = ! empty( $block->context['vp/showCount'] );
+
+		// The filter value and URL are resolved on every request, since the
+		// permalink saved in the editor is wrong for templates and patterns,
+		// and goes stale when the post slug changes.
+		$filter_value = self::get_filter_value( $attributes, $block->context['vp/queryType'] ?? 'posts' );
+
+		// The term this item points at was deleted, there is nothing to filter by.
+		if ( false === $filter_value ) {
+			return '';
 		}
 
-		// Get current filter from URL and extract the actual value.
-		$current_filter = '';
-		if ( isset( $_GET['vp_filter'] ) && ! empty( $_GET['vp_filter'] ) ) {
-			$is_active      = false;
-			$current_filter = sanitize_text_field( urldecode( $_GET['vp_filter'] ) );
-
-			// Remove taxonomy prefix (e.g., 'portfolio_category:mountains' -> 'mountains').
-			if ( false !== strpos( $current_filter, ':' ) ) {
-				$parts          = explode( ':', $current_filter );
-				$current_filter = end( $parts );
-			}
-		}
+		$filter_link = Visual_Portfolio_Get::get_pagenum_link(
+			array(
+				'vp_filter' => $filter_value,
+				'vp_page'   => 1,
+			)
+		);
 
 		// Determine if this item should be active.
-		$should_be_active = false;
+		$current_filter = Visual_Portfolio_Get::get_filter_active_item( array() );
 
-		if ( '*' === $filter ) {
-			// "All" filter is active only when no filter is set in URL
-			$should_be_active = empty( $current_filter );
+		if ( $is_all ) {
+			// The "All" item is active only when no filter is set in the URL.
+			$is_active = ! $current_filter;
 		} else {
-			// Specific filter is active when it matches the URL parameter.
-			$should_be_active = ( ! empty( $current_filter ) && $current_filter === $filter );
-
-			if ( ! $should_be_active ) {
-				$should_be_active = $is_active;
-			}
+			$is_active = $current_filter && rawurldecode( $filter_value ) === $current_filter;
 		}
 
 		// Get block wrapper attributes but override the class completely.
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
-				'class' => 'vp-block-filter-by-category-item' . ( $should_be_active ? ' is-active' : '' ),
+				'class' => 'vp-block-filter-by-category-item' . ( $is_active ? ' is-active' : '' ),
 			)
 		);
 
-		$output_text = $text;
+		$output_text = wp_kses_post( $text );
 
 		// Build the count display.
 		if ( $show_count && ! $is_all && $count > 0 ) {
-			$output_text = $output_text . '<span class="vp-block-filter-by-category-count">' . $count . '</span>';
+			$output_text .= '<span class="vp-block-filter-by-category-count">' . esc_html( number_format_i18n( $count ) ) . '</span>';
 		}
 
-		$output = '';
-
-		$filter_link = '#';
-		if ( ! empty( $url ) ) {
-			$filter_link = esc_url( $url );
-		}
-
-		if ( $should_be_active ) {
-			$aria_label = '*' === $filter ? esc_attr__( 'Currently displaying all items', 'visual-portfolio' ) : sprintf(
-				// translators: %1$s filter name, %2$s item count.
-				esc_attr__( 'Currently filtering by %1$s, %2$s items', 'visual-portfolio' ),
-				esc_attr( $text ),
-				$count
-			);
-
-			$output = sprintf(
-				'<span aria-label="%1$s" aria-current="page" %2$s>%3$s</span>',
-				$aria_label,
+		// The active item is not a link, so an `aria-label` on it would be
+		// ignored - `aria-current` carries the state instead.
+		if ( $is_active ) {
+			return sprintf(
+				'<span aria-current="page" %1$s>%2$s</span>',
 				$wrapper_attributes,
 				$output_text
 			);
+		}
+
+		if ( $is_all ) {
+			$aria_label = __( 'Display all items', 'visual-portfolio' );
 		} else {
-			$aria_label = '*' === $filter ? esc_attr__( 'Display all items', 'visual-portfolio' ) : sprintf(
-				// translators: %1$s filter name, %2$s item count.
-				esc_attr__( 'Filter by %1$s, %2$s items', 'visual-portfolio' ),
-				esc_attr( $text ),
-				$count
-			);
-
-			$output = sprintf(
-				'<a aria-label="%1$s" href="%2$s" %3$s>%4$s</a>',
-				$aria_label,
-				$filter_link,
-				$wrapper_attributes,
-				$output_text
+			$aria_label = sprintf(
+				// translators: %s filter name.
+				__( 'Filter by %s', 'visual-portfolio' ),
+				wp_strip_all_tags( $text )
 			);
 		}
 
-		return $output;
+		return sprintf(
+			'<a aria-label="%1$s" href="%2$s" %3$s>%4$s</a>',
+			esc_attr( $aria_label ),
+			esc_url( $filter_link ),
+			$wrapper_attributes,
+			$output_text
+		);
 	}
 }
 new Visual_Portfolio_Block_Filter_By_Category_Item();

--- a/gutenberg/blocks/filter-by-category-item/index.php
+++ b/gutenberg/blocks/filter-by-category-item/index.php
@@ -84,8 +84,8 @@ class Visual_Portfolio_Block_Filter_By_Category_Item {
 		$is_all = '*' === $filter;
 		$text   = $attributes['text'] ?? '';
 
-		// Get showCount from parent block context. The parent also provides it
-		// under its old, longer key, which is deprecated but still consumable.
+		// Get showCount from parent block context. The parent still provides it
+		// under its old, longer key too, for blocks that consume that one.
 		$show_count = ! empty( $block->context['vp/showCount'] );
 
 		// The filter value and URL are resolved on every request, since the

--- a/gutenberg/blocks/filter-by-category/block.json
+++ b/gutenberg/blocks/filter-by-category/block.json
@@ -52,6 +52,7 @@
 		"vp/imagesQuery"
 	],
 	"providesContext": {
+		"vp/showCount": "showCount",
 		"visual-portfolio-filter-by-category/showCount": "showCount"
 	},
 	"styles": [{ "name": "fill", "label": "Fill" }],

--- a/gutenberg/blocks/filter-by-category/edit.js
+++ b/gutenberg/blocks/filter-by-category/edit.js
@@ -90,6 +90,13 @@ export default function BlockEdit({
 	const { getBlocks } = useSelect(blockEditorStore);
 	const { replaceInnerBlocks } = useDispatch(blockEditorStore);
 
+	// This block does not use the `url` the endpoint returns - it is rebuilt at
+	// render time - but the endpoint is public and needs the post to build it.
+	const postId = useSelect(
+		(select) => select('core/editor')?.getCurrentPostId(),
+		[]
+	);
+
 	const queryKey = JSON.stringify({
 		queryType,
 		source: postsQuery?.source,
@@ -121,6 +128,7 @@ export default function BlockEdit({
 				baseQuery,
 				postsQuery,
 				imagesQuery,
+				post_id: postId,
 				block_id: clientId,
 			},
 		})
@@ -143,6 +151,13 @@ export default function BlockEdit({
 					);
 
 					if (!item) {
+						// Opening a post must not delete what it already
+						// carries: an item the query no longer returns may be
+						// hand-made, and its `lock` forbids removing it by hand.
+						if (structureOnly) {
+							updatedBlocks.push(block);
+						}
+
 						return;
 					}
 
@@ -180,8 +195,6 @@ export default function BlockEdit({
 					);
 				});
 
-				syncedQueryRef.current = queryKey;
-
 				// Untouched items are returned by identity, so this also tells
 				// us whether anything is worth writing to the editor store.
 				const isUnchanged =
@@ -199,9 +212,15 @@ export default function BlockEdit({
 				console.error('Error fetching filter items:', error);
 			})
 			.finally(() => {
-				if (!cancelled) {
-					setIsLoading(false);
+				if (cancelled) {
+					return;
 				}
+
+				// Marked even when the request failed, so a single failure does
+				// not pin every later sync to the first-sync behaviour.
+				syncedQueryRef.current = queryKey;
+
+				setIsLoading(false);
 			});
 
 		return () => {
@@ -213,6 +232,7 @@ export default function BlockEdit({
 		baseQuery,
 		postsQuery,
 		imagesQuery,
+		postId,
 		clientId,
 		getBlocks,
 		replaceInnerBlocks,

--- a/gutenberg/blocks/filter-by-category/edit.js
+++ b/gutenberg/blocks/filter-by-category/edit.js
@@ -10,7 +10,52 @@ import { PanelBody, Spinner, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { isEqual } from 'lodash';
+
+const ITEM_BLOCK = 'visual-portfolio/filter-by-category-item';
+
+/**
+ * Identify a filter item.
+ *
+ * Term IDs are used where available and the filter slug otherwise, since image
+ * categories are not terms and all report ID 0. Matching on the slug alone
+ * would collide between two taxonomies sharing a slug.
+ *
+ * @param {Object} item - filter item from the REST response or block attributes.
+ * @return {string} unique key.
+ */
+function getItemKey(item) {
+	const id = item.id ?? item.taxonomyId ?? 0;
+
+	return `${id}:${item.filter}`;
+}
+
+/**
+ * Attributes this block owns and keeps in sync with the query.
+ *
+ * On the first sync only the structure is refreshed, so that opening a post
+ * does not silently rewrite labels and counts the user may have edited.
+ *
+ * @param {Object}  item          - filter item from the REST response.
+ * @param {boolean} structureOnly - skip the display data.
+ * @return {Object} block attributes.
+ */
+function getItemAttributes(item, structureOnly) {
+	const isAll = '*' === item.filter;
+
+	const attributes = {
+		filter: item.filter,
+		isAll,
+		taxonomyId: item.id,
+		parentId: item.parent,
+	};
+
+	if (!structureOnly) {
+		attributes.text = isAll ? __('All', 'visual-portfolio') : item.label;
+		attributes.count = item.count || 0;
+	}
+
+	return attributes;
+}
 
 export default function BlockEdit({
 	attributes,
@@ -18,9 +63,11 @@ export default function BlockEdit({
 	context,
 	clientId,
 }) {
-	const [isLoading, setIsLoading] = useState(true);
-	const previousContextRef = useRef(null);
-	const initialLoadDone = useRef(false);
+	const [isLoading, setIsLoading] = useState(false);
+
+	// Key of the query the current items were fetched for. Items live in the
+	// post content, so there is nothing to fetch until the query changes.
+	const syncedQueryRef = useRef(null);
 
 	const {
 		'vp/queryType': queryType,
@@ -29,196 +76,138 @@ export default function BlockEdit({
 		'vp/postsQuery': postsQuery,
 	} = context;
 
-	const images = imagesQuery.images;
-	const postsSource = postsQuery.source;
-	const postsTaxonomies = postsQuery.taxonomies;
+	// Selectors are read inside the effect: the items are driven by the query,
+	// and depending on the block list would re-run the effect on its own writes.
+	const { getBlocks } = useSelect(blockEditorStore);
+	const { replaceInnerBlocks } = useDispatch(blockEditorStore);
 
-	const itemsCount = baseQuery?.perPage || 6;
-
-	const { currentBlocks, hasInnerBlocks, selectedBlockClientId, postId } =
-		useSelect(
-			(select) => ({
-				currentBlocks: select(blockEditorStore).getBlocks(clientId),
-				hasInnerBlocks:
-					select(blockEditorStore).getBlocks(clientId).length > 0,
-				selectedBlockClientId:
-					select(blockEditorStore).getSelectedBlockClientId(),
-				postId: select('core/editor')?.getCurrentPostId(),
-			}),
-			[clientId]
-		);
-
-	const { replaceInnerBlocks, selectBlock } = useDispatch(blockEditorStore);
+	const queryKey = JSON.stringify({
+		queryType,
+		source: postsQuery?.source,
+		taxonomies: postsQuery?.taxonomies,
+		images: imagesQuery?.images,
+	});
 
 	useEffect(() => {
-		const hasContextChanged = () => {
-			const currentContext = {
+		if (syncedQueryRef.current === queryKey) {
+			return undefined;
+		}
+
+		// Saved content already carries its items, so the first sync only fills
+		// in what is missing instead of rewriting what is there.
+		const structureOnly = null === syncedQueryRef.current;
+		const currentBlocks = getBlocks(clientId);
+
+		let cancelled = false;
+
+		if (!currentBlocks.length) {
+			setIsLoading(true);
+		}
+
+		apiFetch({
+			path: '/visual-portfolio/v1/get_filter_items/',
+			method: 'POST',
+			data: {
 				queryType,
+				baseQuery,
 				postsQuery,
 				imagesQuery,
-				postsSource,
-				postsTaxonomies,
-				images,
-				postId,
-			};
+				block_id: clientId,
+			},
+		})
+			.then((response) => {
+				if (cancelled || !response?.success) {
+					return;
+				}
 
-			if (!previousContextRef.current) {
-				previousContextRef.current = currentContext;
-				return true;
-			}
+				const items = response.response;
+				const matched = new Set();
 
-			const hasChanged = !isEqual(
-				previousContextRef.current,
-				currentContext
-			);
-			if (hasChanged) {
-				previousContextRef.current = currentContext;
-			}
+				// Keep the existing items in their current order, so manual
+				// reordering survives a refresh.
+				const updatedBlocks = [];
 
-			return hasChanged;
-		};
+				currentBlocks.forEach((block) => {
+					const key = getItemKey(block.attributes);
+					const item = items.find(
+						(candidate) => getItemKey(candidate) === key
+					);
 
-		const fetchFilterItems = async () => {
-			if (hasInnerBlocks && !initialLoadDone.current) {
-				initialLoadDone.current = true;
-				setIsLoading(false);
-				return;
-			}
+					if (!item) {
+						return;
+					}
 
-			if (!hasContextChanged() && hasInnerBlocks) {
-				setIsLoading(false);
-				return;
-			}
+					matched.add(key);
 
-			setIsLoading(true);
+					const newAttributes = getItemAttributes(
+						item,
+						structureOnly
+					);
+					const hasChanges = Object.keys(newAttributes).some(
+						(name) => block.attributes[name] !== newAttributes[name]
+					);
 
-			try {
-				const requestData = {
-					baseQuery,
-					imagesQuery,
-					post_id: postId,
-					postsQuery,
-					queryType,
-				};
-
-				// Add block ID
-				requestData.block_id = clientId;
-
-				// Make API request with data in the body
-				const response = await apiFetch({
-					path: '/visual-portfolio/v1/get_filter_items/',
-					method: 'POST',
-					data: requestData, // Send data in request body instead of URL
+					updatedBlocks.push(
+						hasChanges
+							? {
+									...block,
+									attributes: {
+										...block.attributes,
+										...newAttributes,
+									},
+								}
+							: block
+					);
 				});
 
-				if (response?.success) {
-					const updatedBlocks = [];
-					const processedFilters = new Set();
-
-					// First, maintain order of existing blocks and update their data
-					currentBlocks.forEach((block) => {
-						const filterValue = block.attributes.filter;
-						const newData = response.response.find(
-							(item) => item.filter === filterValue
-						);
-
-						if (newData) {
-							updatedBlocks.push({
-								...block,
-								attributes: {
-									...block.attributes,
-									text: newData.label,
-									filter: newData.filter,
-									url: newData.url,
-									taxonomyId: newData.id,
-									parentId: newData.parent,
-									isActive: newData.active,
-									count: newData.count || 0,
-								},
-							});
-							processedFilters.add(filterValue);
-						}
-					});
-
-					// Add new blocks that don't exist in current blocks
-					const newBlocks = response.response
-						.filter((item) => !processedFilters.has(item.filter))
-						.map((item) => {
-							const isAll = item.filter === '*';
-							return createBlock(
-								'visual-portfolio/filter-by-category-item',
-								{
-									text: isAll
-										? __('All', 'visual-portfolio')
-										: item.label,
-									filter: item.filter,
-									url: item.url,
-									taxonomyId: item.id,
-									parentId: item.parent,
-									isActive: item.active,
-									count: item.count || 0,
-								}
-							);
-						});
-
-					// Combine updated blocks with new ones
-					const finalBlocks = [...updatedBlocks, ...newBlocks];
-
-					// Store the current selection
-					const currentSelection = selectedBlockClientId;
-
-					// Update blocks
-					replaceInnerBlocks(clientId, finalBlocks, false);
-
-					// Restore the selection
-					if (currentSelection && currentSelection !== clientId) {
-						setTimeout(() => {
-							selectBlock(currentSelection);
-						}, 0);
+				// Append the items that are not in the block list yet.
+				items.forEach((item) => {
+					if (matched.has(getItemKey(item))) {
+						return;
 					}
+
+					updatedBlocks.push(
+						createBlock(ITEM_BLOCK, getItemAttributes(item, false))
+					);
+				});
+
+				syncedQueryRef.current = queryKey;
+
+				// Untouched items are returned by identity, so this also tells
+				// us whether anything is worth writing to the editor store.
+				const isUnchanged =
+					updatedBlocks.length === currentBlocks.length &&
+					updatedBlocks.every(
+						(block, index) => block === currentBlocks[index]
+					);
+
+				if (!isUnchanged) {
+					replaceInnerBlocks(clientId, updatedBlocks, false);
 				}
-			} catch (error) {
+			})
+			.catch((error) => {
 				// eslint-disable-next-line no-console
 				console.error('Error fetching filter items:', error);
-			}
+			})
+			.finally(() => {
+				if (!cancelled) {
+					setIsLoading(false);
+				}
+			});
 
-			setIsLoading(false);
+		return () => {
+			cancelled = true;
 		};
-
-		fetchFilterItems();
 	}, [
+		queryKey,
 		queryType,
-		postsSource,
-		postsTaxonomies,
-		images,
-		clientId,
-		hasInnerBlocks,
-		currentBlocks,
-		selectedBlockClientId,
-		replaceInnerBlocks,
-		selectBlock,
-		postId,
-		itemsCount,
-		attributes.showCount,
 		baseQuery,
-		imagesQuery,
 		postsQuery,
+		imagesQuery,
+		clientId,
+		getBlocks,
+		replaceInnerBlocks,
 	]);
-
-	useEffect(() => {
-		if (hasInnerBlocks && !isLoading) {
-			// Force re-render of inner blocks when showCount changes
-			const updatedBlocks = currentBlocks.map((block) => ({
-				...block,
-				attributes: {
-					...block.attributes,
-					// This will trigger a re-render
-					__timestamp: Date.now(),
-				},
-			}));
-			replaceInnerBlocks(clientId, updatedBlocks, false);
-		}
-	}, [attributes.showCount]);
 
 	const blockProps = useBlockProps({
 		className: 'vp-block-filter-by-category',
@@ -227,7 +216,7 @@ export default function BlockEdit({
 	const innerBlocksProps = useInnerBlocksProps(blockProps, {
 		orientation: 'horizontal',
 		renderAppender: false,
-		templateLock: false, // Changed from 'all' to false to allow moving
+		templateLock: false,
 	});
 
 	return (
@@ -235,6 +224,7 @@ export default function BlockEdit({
 			<InspectorControls>
 				<PanelBody>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						label={__('Display Count', 'visual-portfolio')}
 						checked={attributes.showCount}
 						onChange={() =>

--- a/gutenberg/blocks/filter-by-category/edit.js
+++ b/gutenberg/blocks/filter-by-category/edit.js
@@ -32,14 +32,16 @@ function getItemKey(item) {
 /**
  * Attributes this block owns and keeps in sync with the query.
  *
- * On the first sync only the structure is refreshed, so that opening a post
- * does not silently rewrite labels and counts the user may have edited.
- *
- * @param {Object}  item          - filter item from the REST response.
- * @param {boolean} structureOnly - skip the display data.
+ * @param {Object}  item                  - filter item from the REST response.
+ * @param {Object}  [options]             - sync options.
+ * @param {boolean} [options.structureOnly] - first sync of already saved items.
+ * @param {Object}  [options.current]     - attributes the item already has.
  * @return {Object} block attributes.
  */
-function getItemAttributes(item, structureOnly) {
+function getItemAttributes(
+	item,
+	{ structureOnly = false, current = null } = {}
+) {
 	const isAll = '*' === item.filter;
 
 	const attributes = {
@@ -49,8 +51,15 @@ function getItemAttributes(item, structureOnly) {
 		parentId: item.parent,
 	};
 
+	// The label can be edited by hand, so the first sync leaves it as saved.
 	if (!structureOnly) {
 		attributes.text = isAll ? __('All', 'visual-portfolio') : item.label;
+	}
+
+	// Counts are server data, but rewriting a count that merely drifted would
+	// mark the post as modified just from opening it. A missing count is filled
+	// in regardless, otherwise "Display Count" has nothing to show.
+	if (!structureOnly || !current?.count) {
 		attributes.count = item.count || 0;
 	}
 
@@ -139,10 +148,10 @@ export default function BlockEdit({
 
 					matched.add(key);
 
-					const newAttributes = getItemAttributes(
-						item,
-						structureOnly
-					);
+					const newAttributes = getItemAttributes(item, {
+						structureOnly,
+						current: block.attributes,
+					});
 					const hasChanges = Object.keys(newAttributes).some(
 						(name) => block.attributes[name] !== newAttributes[name]
 					);
@@ -167,7 +176,7 @@ export default function BlockEdit({
 					}
 
 					updatedBlocks.push(
-						createBlock(ITEM_BLOCK, getItemAttributes(item, false))
+						createBlock(ITEM_BLOCK, getItemAttributes(item))
 					);
 				});
 

--- a/gutenberg/blocks/filter-by-category/index.php
+++ b/gutenberg/blocks/filter-by-category/index.php
@@ -53,7 +53,8 @@ class Visual_Portfolio_Block_Filter_By_Category {
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
 				'class'      => 'vp-block-filter-by-category',
-				'aria-label' => esc_attr__( 'Category filter', 'visual-portfolio' ),
+				// `get_block_wrapper_attributes()` escapes the values itself.
+				'aria-label' => __( 'Category filter', 'visual-portfolio' ),
 			)
 		);
 

--- a/gutenberg/blocks/filter-by-category/style.scss
+++ b/gutenberg/blocks/filter-by-category/style.scss
@@ -18,27 +18,24 @@
 }
 
 // Fill style.
+//
+// Every item gets a filled pill and the active one a stronger fill. Spacing is
+// left to the block gap, so the setting in the editor still applies.
 .vp-block-filter-by-category.is-style-fill {
-	gap: 0;
-
-	a {
-		text-decoration: none;
-	}
-
 	.vp-block-filter-by-category-item {
 		border-radius: 9999px;
 		padding: 0.3em 0.8em;
-		background-color: transparent;
+		background-color: color-mix(in srgb, currentColor 7%, transparent);
 		text-decoration: none;
 		font-weight: 400;
 
 		&:hover,
 		&:focus {
-			opacity: 0.6;
+			background-color: color-mix(in srgb, currentColor 12%, transparent);
 		}
 
 		&.is-active {
-			background-color: color-mix(in srgb, currentColor 10%, transparent);
+			background-color: color-mix(in srgb, currentColor 18%, transparent);
 		}
 	}
 }

--- a/gutenberg/blocks/filter-by-category/style.scss
+++ b/gutenberg/blocks/filter-by-category/style.scss
@@ -1,4 +1,4 @@
-// Pagination block.
+// Filter by category block.
 .vp-block-filter-by-category {
 	font-size: var(--wp--preset--font-size--medium, 1rem);
 	font-weight: 500;
@@ -18,13 +18,11 @@
 }
 
 // Fill style.
-.is-style-fill {
-	&.vp-block-filter-by-category {
-		gap: 0;
+.vp-block-filter-by-category.is-style-fill {
+	gap: 0;
 
-		a {
-			text-decoration: none;
-		}
+	a {
+		text-decoration: none;
 	}
 
 	.vp-block-filter-by-category-item {

--- a/gutenberg/blocks/filter-by-category/view.js
+++ b/gutenberg/blocks/filter-by-category/view.js
@@ -1,12 +1,11 @@
 import $ from 'jquery';
 
+import { getLoopGallery } from '../../utils/loop-gallery';
+
 const $doc = $(document);
 
 $doc.on('click', '.vp-block-filter-by-category a', (e) => {
-	const $current = $(e.currentTarget);
-	const $loop = $current.closest('.vp-block-loop');
-	const $legacyBlock = $loop.find('.vp-portfolio');
-	const vpf = $legacyBlock?.[0]?.vpf;
+	const vpf = getLoopGallery(e.currentTarget);
 
 	if (!vpf) {
 		return;
@@ -14,5 +13,5 @@ $doc.on('click', '.vp-block-filter-by-category a', (e) => {
 
 	e.preventDefault();
 
-	vpf.loadNewItems($current.attr('href'), true);
+	vpf.loadNewItems($(e.currentTarget).attr('href'), true);
 });

--- a/gutenberg/blocks/loop/block.json
+++ b/gutenberg/blocks/loop/block.json
@@ -54,7 +54,7 @@
 			}
 		},
 		"customCss": { "type": "string", "default": "" },
-		"previewImageExample": { "type": "string", "default": "" },
+		"preview_image_example": { "type": "string", "default": "" },
 		"setupWizard": { "type": "string", "default": "" }
 	},
 	"supports": {
@@ -93,7 +93,7 @@
 	},
 	"example": {
 		"attributes": {
-			"preview_image_example": true,
+			"preview_image_example": "true",
 			"layout": "justified"
 		}
 	},

--- a/gutenberg/blocks/loop/edit.js
+++ b/gutenberg/blocks/loop/edit.js
@@ -7,13 +7,15 @@ import {
 import { useEffect, useRef } from '@wordpress/element';
 
 import ControlsRender from '../../components/controls-render';
+import { LOOP_GENERAL_CONTROLS, pickControls } from '../../utils/loop-controls';
 
 const {
 	plugin_url: pluginUrl,
 	controls_categories: registeredControlsCategories,
 } = window.VPGutenbergVariables;
 
-// Content source categories to display
+// Content source categories to display. Anything outside this list belongs to
+// the gallery block inside the loop, which is what renders it.
 const ALLOWED_CONTROL_CATEGORIES = [
 	'content-source',
 	'content-source-general',
@@ -21,20 +23,37 @@ const ALLOWED_CONTROL_CATEGORIES = [
 	'content-source-post-based',
 	'content-source-taxonomies',
 	'content-source-social-stream',
-	'custom_css',
 ];
 
-function filterControlCategories(categories) {
-	return Object.fromEntries(
-		Object.entries(categories).filter(([key]) =>
-			ALLOWED_CONTROL_CATEGORIES.includes(key)
-		)
-	);
-}
+const TEMPLATE = [
+	[
+		'visual-portfolio/filter-by-category',
+		{},
+		// A placeholder until the filter block has fetched its items. It carries
+		// the default `filter` of `*`, so the fetched "All" item reuses it.
+		[
+			[
+				'visual-portfolio/filter-by-category-item',
+				{ text: 'All', isAll: true },
+			],
+		],
+	],
+	['visual-portfolio/block', { setup_wizard: 'false' }],
+	[
+		'visual-portfolio/pagination',
+		{},
+		[
+			['visual-portfolio/pagination-previous'],
+			['visual-portfolio/pagination-numbers'],
+			['visual-portfolio/pagination-next'],
+		],
+	],
+];
 
 function renderControls(props) {
-	const { attributes } = props;
-	const { queryType } = attributes;
+	const categories = Object.keys(registeredControlsCategories).filter(
+		(name) => ALLOWED_CONTROL_CATEGORIES.includes(name)
+	);
 
 	return (
 		<>
@@ -44,30 +63,25 @@ function renderControls(props) {
 				{...props}
 			/>
 
-			{queryType &&
-				Object.keys(
-					filterControlCategories(registeredControlsCategories)
-				)
-					.filter((name) => name !== 'content-source')
-					.map((name) => (
-						<ControlsRender
-							isModernBlock
-							key={name}
-							category={name}
-							{...props}
-						/>
-					))}
+			{categories
+				.filter((name) => name !== 'content-source')
+				.map((name) => (
+					<ControlsRender
+						isModernBlock
+						key={name}
+						category={name}
+						// Only some of the general settings are query settings,
+						// the rest are no-ops on this block.
+						controls={
+							'content-source-general' === name
+								? pickControls(LOOP_GENERAL_CONTROLS)
+								: undefined
+						}
+						{...props}
+					/>
+				))}
 		</>
 	);
-}
-
-// Debounce function to prevent too many API calls
-function debounce(func, wait) {
-	let timeout;
-	return (...args) => {
-		clearTimeout(timeout);
-		timeout = setTimeout(() => func(...args), wait);
-	};
 }
 
 /**
@@ -75,117 +89,121 @@ function debounce(func, wait) {
  * @param props
  */
 export default function BlockEdit(props) {
-	const { attributes, clientId, setAttributes } = props;
+	const { attributes, setAttributes } = props;
 
 	const {
 		layout,
 		queryType,
 		baseQuery,
+		postsQuery,
 		imagesQuery,
 		preview_image_example: previewExample,
 	} = attributes;
 
-	// Create a ref to track previous attribute values
-	const prevAttributesRef = useRef({});
+	// Read when a request resolves, so the pending value is never stale.
+	const baseQueryRef = useRef(baseQuery);
 
-	// Function to update maxPages via REST API
-	const updateMaxPages = debounce(async () => {
-		if (!queryType || !baseQuery.perPage) {
-			return;
+	useEffect(() => {
+		baseQueryRef.current = baseQuery;
+	}, [baseQuery]);
+
+	// Everything the endpoint needs, and the only thing that should trigger it.
+	// `maxPages` is deliberately left out - it is what the request writes back.
+	const queryKey = JSON.stringify({
+		queryType,
+		baseQuery: { perPage: baseQuery?.perPage },
+		postsQuery,
+		imagesQuery,
+	});
+
+	// `maxPages` drives the editor preview of the pagination blocks. The front
+	// end recalculates it per request, since saved content goes stale.
+	useEffect(() => {
+		const query = JSON.parse(queryKey);
+
+		if (!query.queryType || !query.baseQuery.perPage) {
+			return undefined;
 		}
 
-		try {
-			// Create a data object instead of query params
-			const requestData = {};
-
-			// Add all attributes to the request data
-			Object.entries(attributes).forEach(([key, value]) => {
-				if (value !== null) {
-					requestData[key] = value;
-				}
-			});
-
-			// Add block ID
-			requestData.block_id = clientId;
-
-			// Make API request with data in the body
-			const response = await apiFetch({
-				path: '/visual-portfolio/v1/get-max-pages/',
+		// Settings are usually changed in bursts - only ask once they settle.
+		const timeout = setTimeout(() => {
+			apiFetch({
+				path: '/visual-portfolio/v1/get_max_pages/',
 				method: 'POST',
-				data: requestData, // Send data in request body instead of URL
-			});
+				data: query,
+			})
+				.then((response) => {
+					const maxPages = parseInt(response?.max_pages, 10);
 
-			// Update maxPages attribute if available in response
-			if (response?.max_pages !== undefined) {
-				setAttributes({
-					baseQuery: {
-						...baseQuery,
-						maxPages: parseInt(response.max_pages, 10),
-					},
+					if (
+						!maxPages ||
+						maxPages === baseQueryRef.current?.maxPages
+					) {
+						return;
+					}
+
+					setAttributes({
+						baseQuery: {
+							...baseQueryRef.current,
+							maxPages,
+						},
+					});
+				})
+				.catch((error) => {
+					// eslint-disable-next-line no-console
+					console.error('Error fetching max pages:', error);
 				});
-			}
-		} catch (error) {
-			// eslint-disable-next-line no-console
-			console.error('Error fetching max pages:', error);
-		}
-	}, 500);
+		}, 500);
 
-	// Update maxPages when relevant attributes change
+		return () => clearTimeout(timeout);
+	}, [queryKey, setAttributes]);
+
 	useEffect(() => {
-		if (!queryType || !baseQuery.perPage) {
+		if ('images' !== queryType || !Array.isArray(imagesQuery.images)) {
 			return;
 		}
 
-		// Compare with previous values to avoid unnecessary API calls
-		const prevAttrs = prevAttributesRef.current;
-		const hasChanged = Object.keys(attributes).some(
-			(key) =>
-				JSON.stringify(prevAttrs[key]) !==
-				JSON.stringify(attributes[key])
-		);
+		// Extract all categories from images
+		const newCategories = new Set();
 
-		if (hasChanged) {
-			updateMaxPages();
-			prevAttributesRef.current = { ...attributes };
-		}
-	}, [attributes, queryType, baseQuery.perPage, updateMaxPages]);
-
-	useEffect(() => {
-		if (queryType === 'images' && Array.isArray(imagesQuery.images)) {
-			// Extract all categories from images
-			const newCategories = new Set();
-
-			imagesQuery.images.forEach((image) => {
-				if (image.categories && Array.isArray(image.categories)) {
-					image.categories.forEach((category) => {
-						newCategories.add(category);
-					});
-				}
-			});
-
-			// Convert Set to Array
-			const newCategoriesArray = Array.from(newCategories);
-
-			// Check if the new categories are different from the current ones
-			const currentCategories = imagesQuery.categories || [];
-			const categoriesChanged =
-				JSON.stringify(currentCategories) !==
-				JSON.stringify(newCategoriesArray);
-
-			// Update the imagesQuery.categories attribute if there are changes
-			if (categoriesChanged) {
-				setAttributes({
-					imagesQuery: {
-						...imagesQuery,
-						categories: newCategoriesArray,
-					},
+		imagesQuery.images.forEach((image) => {
+			if (image.categories && Array.isArray(image.categories)) {
+				image.categories.forEach((category) => {
+					newCategories.add(category);
 				});
 			}
+		});
+
+		// Convert Set to Array
+		const newCategoriesArray = Array.from(newCategories);
+
+		// Check if the new categories are different from the current ones
+		const currentCategories = imagesQuery.categories || [];
+		const categoriesChanged =
+			JSON.stringify(currentCategories) !==
+			JSON.stringify(newCategoriesArray);
+
+		// Update the imagesQuery.categories attribute if there are changes
+		if (categoriesChanged) {
+			setAttributes({
+				imagesQuery: {
+					...imagesQuery,
+					categories: newCategoriesArray,
+				},
+			});
 		}
 	}, [queryType, setAttributes, imagesQuery]);
 
-	// Display block preview if needed
-	if (previewExample === 'true') {
+	const blockProps = useBlockProps({ className: 'vp-block-loop' });
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			template: TEMPLATE,
+		}
+	);
+
+	// Display block preview if needed.
+	if ('true' === previewExample) {
 		return (
 			<div className="vpf-example-preview">
 				<img
@@ -195,41 +213,6 @@ export default function BlockEdit(props) {
 			</div>
 		);
 	}
-
-	// Set up block props
-	const blockProps = useBlockProps({ className: 'vp-block-loop' });
-	const innerBlocksProps = useInnerBlocksProps(
-		{},
-		{
-			template: [
-				[
-					'visual-portfolio/filter-by-category',
-					{},
-					[
-						[
-							'visual-portfolio/filter-by-category-item',
-							{
-								text: 'All',
-								isAll: true,
-								url: '#',
-								isActive: true,
-							},
-						],
-					],
-				],
-				['visual-portfolio/block', { setup_wizard: 'false' }],
-				[
-					'visual-portfolio/pagination',
-					{},
-					[
-						['visual-portfolio/pagination-previous'],
-						['visual-portfolio/pagination-numbers'],
-						['visual-portfolio/pagination-next'],
-					],
-				],
-			],
-		}
-	);
 
 	return (
 		<div {...blockProps}>

--- a/gutenberg/blocks/loop/edit.js
+++ b/gutenberg/blocks/loop/edit.js
@@ -125,6 +125,9 @@ export default function BlockEdit(props) {
 			return undefined;
 		}
 
+		// `clearTimeout` only stops a request that has not gone out yet.
+		let cancelled = false;
+
 		// Settings are usually changed in bursts - only ask once they settle.
 		const timeout = setTimeout(() => {
 			apiFetch({
@@ -136,6 +139,7 @@ export default function BlockEdit(props) {
 					const maxPages = parseInt(response?.max_pages, 10);
 
 					if (
+						cancelled ||
 						!maxPages ||
 						maxPages === baseQueryRef.current?.maxPages
 					) {
@@ -155,7 +159,10 @@ export default function BlockEdit(props) {
 				});
 		}, 500);
 
-		return () => clearTimeout(timeout);
+		return () => {
+			cancelled = true;
+			clearTimeout(timeout);
+		};
 	}, [queryKey, setAttributes]);
 
 	useEffect(() => {

--- a/gutenberg/blocks/loop/edit.js
+++ b/gutenberg/blocks/loop/edit.js
@@ -4,7 +4,7 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 
 import ControlsRender from '../../components/controls-render';
 import { LOOP_GENERAL_CONTROLS, pickControls } from '../../utils/loop-controls';
@@ -58,15 +58,16 @@ function renderControls(props) {
 	return (
 		<>
 			<ControlsRender
+				{...props}
 				isModernBlock
 				category="content-source"
-				{...props}
 			/>
 
 			{categories
 				.filter((name) => name !== 'content-source')
 				.map((name) => (
 					<ControlsRender
+						{...props}
 						isModernBlock
 						key={name}
 						category={name}
@@ -77,7 +78,6 @@ function renderControls(props) {
 								? pickControls(LOOP_GENERAL_CONTROLS)
 								: undefined
 						}
-						{...props}
 					/>
 				))}
 		</>
@@ -109,18 +109,21 @@ export default function BlockEdit(props) {
 
 	// Everything the endpoint needs, and the only thing that should trigger it.
 	// `maxPages` is deliberately left out - it is what the request writes back.
-	const queryKey = JSON.stringify({
-		queryType,
-		baseQuery: { perPage: baseQuery?.perPage },
-		postsQuery,
-		imagesQuery,
-	});
+	// Memoised on the attribute identities, so a gallery with hundreds of images
+	// is not rebuilt on every render.
+	const query = useMemo(
+		() => ({
+			queryType,
+			baseQuery: { perPage: baseQuery?.perPage },
+			postsQuery,
+			imagesQuery,
+		}),
+		[queryType, baseQuery?.perPage, postsQuery, imagesQuery]
+	);
 
 	// `maxPages` drives the editor preview of the pagination blocks. The front
 	// end recalculates it per request, since saved content goes stale.
 	useEffect(() => {
-		const query = JSON.parse(queryKey);
-
 		if (!query.queryType || !query.baseQuery.perPage) {
 			return undefined;
 		}
@@ -163,7 +166,7 @@ export default function BlockEdit(props) {
 			cancelled = true;
 			clearTimeout(timeout);
 		};
-	}, [queryKey, setAttributes]);
+	}, [query, setAttributes]);
 
 	useEffect(() => {
 		if ('images' !== queryType || !Array.isArray(imagesQuery.images)) {

--- a/gutenberg/blocks/loop/view.js
+++ b/gutenberg/blocks/loop/view.js
@@ -2,6 +2,8 @@ import $ from 'jquery';
 
 const $doc = $(document);
 
+const LIVE_REGION_CLASS = 'vp-block-loop-live-region';
+
 // Define the block selectors we need to replace after ajax loading.
 const blockSelectors = [
 	'.vp-block-filter-by-category',
@@ -9,16 +11,44 @@ const blockSelectors = [
 	'.vp-block-pagination',
 ];
 
+/**
+ * Announce AJAX updates to screen readers.
+ *
+ * A live region is only announced when its content changes while it is already
+ * in the document, so every loop gets one up front.
+ */
+function initLiveRegions() {
+	$('.vp-block-loop').each(function () {
+		const $loop = $(this);
+
+		if ($loop.children(`.${LIVE_REGION_CLASS}`).length) {
+			return;
+		}
+
+		$loop.append(
+			$('<div />', {
+				class: `${LIVE_REGION_CLASS} vp-screen-reader-text`,
+				'aria-live': 'polite',
+				'aria-atomic': 'true',
+			})
+		);
+	});
+}
+
+$(initLiveRegions);
+$doc.on('init.vpf', initLiveRegions);
+
 $doc.on('loadedNewItems.vpf', (event, vpObject, $newVP) => {
 	if ('vpf' !== event.namespace) {
 		return;
 	}
 
-	if (!vpObject.$item.closest('.vp-block-loop').length) {
+	const $currentLoop = vpObject.$item.closest('.vp-block-loop');
+
+	if (!$currentLoop.length) {
 		return;
 	}
 
-	const $currentLoop = vpObject.$item.closest('.vp-block-loop');
 	const $newLoop = $newVP.closest('.vp-block-loop');
 
 	// For each block type, find and replace them maintaining order
@@ -37,4 +67,13 @@ $doc.on('loadedNewItems.vpf', (event, vpObject, $newVP) => {
 			}
 		});
 	});
+
+	const message = window.VPData?.__?.loop_items_updated;
+
+	if (message) {
+		$currentLoop.children(`.${LIVE_REGION_CLASS}`).text(message);
+	}
+
+	// The blocks above listen to this to re-attach to their new markup.
+	$currentLoop.trigger('replacedLoopBlocks.vpf', [vpObject]);
 });

--- a/gutenberg/blocks/pagination-infinite/edit.js
+++ b/gutenberg/blocks/pagination-infinite/edit.js
@@ -1,28 +1,57 @@
 /**
  * WordPress dependencies
  */
-import { PlainText, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	PlainText,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function Edit({ attributes, setAttributes }) {
-	const { label } = attributes;
+	const { label, loadingLabel } = attributes;
 
 	return (
-		<a
-			href="#pagination-load-more-pseudo-link"
-			onClick={(event) => event.preventDefault()}
-			{...useBlockProps({
-				className: 'vp-block-pagination-infinite',
-			})}
-		>
-			<PlainText
-				__experimentalVersion={2}
-				tagName="span"
-				aria-label={__('Load more link', 'visual-portfolio')}
-				placeholder={__('Load More', 'visual-portfolio')}
-				value={label}
-				onChange={(newLabel) => setAttributes({ label: newLabel })}
-			/>
-		</a>
+		<>
+			<InspectorControls>
+				<PanelBody>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={__('Loading text', 'visual-portfolio')}
+						help={__(
+							'Announced to screen readers while the next items are loading.',
+							'visual-portfolio'
+						)}
+						value={loadingLabel || ''}
+						placeholder={__('Loading...', 'visual-portfolio')}
+						onChange={(newLabel) =>
+							setAttributes({ loadingLabel: newLabel })
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<a
+				href="#pagination-infinite-pseudo-link"
+				onClick={(event) => event.preventDefault()}
+				{...useBlockProps({
+					className: 'vp-block-pagination-infinite',
+				})}
+			>
+				<PlainText
+					__experimentalVersion={2}
+					tagName="span"
+					aria-label={__(
+						'Infinite scroll trigger',
+						'visual-portfolio'
+					)}
+					placeholder={__('Load More', 'visual-portfolio')}
+					value={label}
+					onChange={(newLabel) => setAttributes({ label: newLabel })}
+				/>
+			</a>
+		</>
 	);
 }

--- a/gutenberg/blocks/pagination-infinite/index.php
+++ b/gutenberg/blocks/pagination-infinite/index.php
@@ -30,8 +30,6 @@ class Visual_Portfolio_Block_Pagination_Infinite {
 				'render_callback' => array( $this, 'block_render' ),
 			)
 		);
-
-		Visual_Portfolio_Assets::store_used_assets( 'visual-portfolio-pagination-infinite', true, 'script' );
 	}
 
 	/**
@@ -44,14 +42,17 @@ class Visual_Portfolio_Block_Pagination_Infinite {
 	 * @return string
 	 */
 	public function block_render( $attributes, $content, $block ) {
-		$max_pages = Visual_Portfolio_Block_Paged_Pagination::get_max_pages( $block->context );
+		$max_pages    = Visual_Portfolio_Block_Paged_Pagination::get_max_pages( $block->context );
+		$current_page = Visual_Portfolio_Get::get_current_page_number();
+
+		// Nothing left to load.
+		if ( $max_pages <= 1 || $current_page >= $max_pages ) {
+			return '';
+		}
 
 		// Get attributes with defaults.
 		$label         = $attributes['label'] ?? __( 'Load More', 'visual-portfolio' );
 		$loading_label = $attributes['loadingLabel'] ?? __( 'Loading...', 'visual-portfolio' );
-
-		// Get current page.
-		$current_page = max( 1, isset( $_GET['vp_page'] ) ? Visual_Portfolio_Security::sanitize_number( $_GET['vp_page'] ) : 1 );
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
@@ -80,7 +81,7 @@ class Visual_Portfolio_Block_Pagination_Infinite {
 		}
 
 		return sprintf(
-			'<a href="%1$s" %2$s><span>%3$s</span><span class="vp-block-pagination-load-more-loading"><span class="vp-spinner"></span><span class="vp-screen-reader-text">%4$s</span></span></a>',
+			'<a href="%1$s" %2$s><span>%3$s</span><span class="vp-block-pagination-infinite-loading"><span class="vp-spinner"></span><span class="vp-screen-reader-text">%4$s</span></span></a>',
 			$next_link,
 			$wrapper_attributes,
 			wp_kses_post( $label ),

--- a/gutenberg/blocks/pagination-load-more/edit.js
+++ b/gutenberg/blocks/pagination-load-more/edit.js
@@ -1,28 +1,54 @@
 /**
  * WordPress dependencies
  */
-import { PlainText, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	PlainText,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function Edit({ attributes, setAttributes }) {
-	const { label } = attributes;
+	const { label, loadingLabel } = attributes;
 
 	return (
-		<a
-			href="#pagination-load-more-pseudo-link"
-			onClick={(event) => event.preventDefault()}
-			{...useBlockProps({
-				className: 'vp-block-pagination-load-more',
-			})}
-		>
-			<PlainText
-				__experimentalVersion={2}
-				tagName="span"
-				aria-label={__('Load more link', 'visual-portfolio')}
-				placeholder={__('Load More', 'visual-portfolio')}
-				value={label}
-				onChange={(newLabel) => setAttributes({ label: newLabel })}
-			/>
-		</a>
+		<>
+			<InspectorControls>
+				<PanelBody>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={__('Loading text', 'visual-portfolio')}
+						help={__(
+							'Announced to screen readers while the next items are loading.',
+							'visual-portfolio'
+						)}
+						value={loadingLabel || ''}
+						placeholder={__('Loading...', 'visual-portfolio')}
+						onChange={(newLabel) =>
+							setAttributes({ loadingLabel: newLabel })
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<a
+				href="#pagination-load-more-pseudo-link"
+				onClick={(event) => event.preventDefault()}
+				{...useBlockProps({
+					className: 'vp-block-pagination-load-more',
+				})}
+			>
+				<PlainText
+					__experimentalVersion={2}
+					tagName="span"
+					aria-label={__('Load more link', 'visual-portfolio')}
+					placeholder={__('Load More', 'visual-portfolio')}
+					value={label}
+					onChange={(newLabel) => setAttributes({ label: newLabel })}
+				/>
+			</a>
+		</>
 	);
 }

--- a/gutenberg/blocks/pagination-load-more/index.php
+++ b/gutenberg/blocks/pagination-load-more/index.php
@@ -30,8 +30,6 @@ class Visual_Portfolio_Block_Pagination_Load_More {
 				'render_callback' => array( $this, 'block_render' ),
 			)
 		);
-
-		Visual_Portfolio_Assets::store_used_assets( 'visual-portfolio-pagination-load-more', true, 'script' );
 	}
 
 	/**
@@ -44,14 +42,17 @@ class Visual_Portfolio_Block_Pagination_Load_More {
 	 * @return string
 	 */
 	public function block_render( $attributes, $content, $block ) {
-		$max_pages = Visual_Portfolio_Block_Paged_Pagination::get_max_pages( $block->context );
+		$max_pages    = Visual_Portfolio_Block_Paged_Pagination::get_max_pages( $block->context );
+		$current_page = Visual_Portfolio_Get::get_current_page_number();
+
+		// Nothing left to load.
+		if ( $max_pages <= 1 || $current_page >= $max_pages ) {
+			return '';
+		}
 
 		// Get attributes with defaults.
 		$label         = $attributes['label'] ?? __( 'Load More', 'visual-portfolio' );
 		$loading_label = $attributes['loadingLabel'] ?? __( 'Loading...', 'visual-portfolio' );
-
-		// Get current page.
-		$current_page = max( 1, isset( $_GET['vp_page'] ) ? Visual_Portfolio_Security::sanitize_number( $_GET['vp_page'] ) : 1 );
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(

--- a/gutenberg/blocks/pagination-next/index.php
+++ b/gutenberg/blocks/pagination-next/index.php
@@ -45,7 +45,7 @@ class Visual_Portfolio_Block_Pagination_Next {
 		$max_pages = Visual_Portfolio_Block_Paged_Pagination::get_max_pages( $block->context );
 
 		// Get current page.
-		$current_page = max( 1, isset( $_GET['vp_page'] ) ? Visual_Portfolio_Security::sanitize_number( $_GET['vp_page'] ) : 1 );
+		$current_page = Visual_Portfolio_Get::get_current_page_number();
 
 		// If only one page or on the last page, don't show pagination.
 		if ( $max_pages <= 1 || $current_page >= $max_pages ) {

--- a/gutenberg/blocks/pagination-numbers/edit.js
+++ b/gutenberg/blocks/pagination-numbers/edit.js
@@ -61,9 +61,10 @@ export default function PaginationNumbersEdit({
 					<RangeControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						label={__('Number of links')}
+						label={__('Number of links', 'visual-portfolio')}
 						help={__(
-							'Specify how many links can appear before and after the current page number. Links to the first, current and last page are always visible.'
+							'Specify how many links can appear before and after the current page number. Links to the first, current and last page are always visible.',
+							'visual-portfolio'
 						)}
 						value={midSize}
 						onChange={(value) => {

--- a/gutenberg/blocks/pagination-numbers/index.php
+++ b/gutenberg/blocks/pagination-numbers/index.php
@@ -56,10 +56,7 @@ class Visual_Portfolio_Block_Pagination_Numbers {
 		);
 
 		// Get current page.
-		$current_page = max( 1, isset( $_GET['vp_page'] ) ? Visual_Portfolio_Security::sanitize_number( $_GET['vp_page'] ) : 1 );
-		if ( $current_page < 1 ) {
-			$current_page = 1;
-		}
+		$current_page = Visual_Portfolio_Get::get_current_page_number();
 
 		$pagination_links = Visual_Portfolio_Get::get_pagination_links(
 			array(

--- a/gutenberg/blocks/pagination-previous/index.php
+++ b/gutenberg/blocks/pagination-previous/index.php
@@ -50,7 +50,7 @@ class Visual_Portfolio_Block_Pagination_Previous {
 		}
 
 		// Get current page.
-		$current_page = max( 1, isset( $_GET['vp_page'] ) ? Visual_Portfolio_Security::sanitize_number( $_GET['vp_page'] ) : 1 );
+		$current_page = Visual_Portfolio_Get::get_current_page_number();
 
 		// If on the first page, don't show the previous link.
 		if ( $current_page <= 1 ) {

--- a/gutenberg/blocks/pagination/edit.js
+++ b/gutenberg/blocks/pagination/edit.js
@@ -3,22 +3,11 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-/**
- * Block constants
- */
-const ALLOWED_BLOCKS = [
-	'visual-portfolio/pagination-previous',
-	'visual-portfolio/pagination-numbers',
-	'visual-portfolio/pagination-next',
-	'visual-portfolio/pagination-load-more',
-	'visual-portfolio/pagination-infinite',
-];
-
 export default function PagedPaginationEdit() {
 	const blockProps = useBlockProps({ className: 'vp-block-pagination' });
 
+	// The allowed blocks are declared in `block.json`.
 	const innerBlocksProps = useInnerBlocksProps(blockProps, {
-		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
 	});
 

--- a/gutenberg/blocks/pagination/index.php
+++ b/gutenberg/blocks/pagination/index.php
@@ -69,7 +69,15 @@ class Visual_Portfolio_Block_Paged_Pagination {
 		}
 
 		// The filter narrows the query, so it is part of the identity here.
-		$cache_key = md5( (string) wp_json_encode( array( $options, Visual_Portfolio_Get::get_filter_active_item( array() ) ) ) );
+		$identity = wp_json_encode( array( $options, Visual_Portfolio_Get::get_filter_active_item( array() ) ) );
+
+		// Without a reliable identity two different loops would share one entry,
+		// which is worse than calculating twice.
+		if ( false === $identity ) {
+			return Visual_Portfolio_Get::calculate_max_pages( $options );
+		}
+
+		$cache_key = md5( $identity );
 
 		if ( ! isset( self::$max_pages_cache[ $cache_key ] ) ) {
 			self::$max_pages_cache[ $cache_key ] = Visual_Portfolio_Get::calculate_max_pages( $options );

--- a/gutenberg/blocks/pagination/index.php
+++ b/gutenberg/blocks/pagination/index.php
@@ -14,6 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Visual_Portfolio_Block_Paged_Pagination {
 	/**
+	 * Calculated max pages, keyed by loop query.
+	 *
+	 * Every pagination block inside a loop asks for the same number, so it is
+	 * only calculated once per request.
+	 *
+	 * @var array
+	 */
+	private static $max_pages_cache = array();
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -40,64 +50,32 @@ class Visual_Portfolio_Block_Paged_Pagination {
 	/**
 	 * Get max pages for all pagination blocks
 	 *
+	 * The `maxPages` value the editor stores in the loop attributes is only a
+	 * preview: it goes stale as soon as the queried content changes. The number
+	 * is calculated from the loop query on every request instead.
+	 *
 	 * @param array $context - Block Loop Context with query block attributes.
 	 * @return int
 	 */
 	public static function get_max_pages( $context ) {
-		// Get context values.
-		$max_pages = $context['vp/baseQuery']['maxPages'] ?? 1;
-
-		// Check if filtering is applied.
-		if ( empty( $_GET['vp_filter'] ) ) {
-			return $max_pages;
+		if ( empty( $context ) || ! is_array( $context ) ) {
+			return 1;
 		}
 
-		// If filter is applied, we need to recalculate max_pages.
-		$rest_api = new Visual_Portfolio_Rest();
+		$options = Visual_Portfolio_Gutenberg::transform_context_to_attributes( $context );
 
-		$base_query = $context['vp/baseQuery'] ?? null;
-
-		// Create base request data.
-		$request_data = array(
-			'content_source' => $context['vp/queryType'] ?? 'posts',
-			'items_count'    => (int) ( $base_query['perPage'] ?? 6 ),
-			'vp_filter'      => sanitize_text_field( wp_unslash( $_GET['vp_filter'] ) ),
-		);
-
-		// Universal mapping: convert all visual-portfolio/* context keys to request parameters.
-		$request_data = array_merge( $request_data, self::map_context_to_request( $context ) );
-
-		return $rest_api->calculate_max_pages( $request_data );
-	}
-
-	/**
-	 * Universal context mapping helper
-	 *
-	 * @param array $context - Block context.
-	 * @return array - Mapped request data
-	 */
-	private static function map_context_to_request( $context ) {
-		$request_data = array();
-		$prefix       = 'vp/';
-
-		foreach ( $context as $key => $value ) {
-			// Skip if key doesn't start with our prefix.
-			if ( strpos( $key, $prefix ) !== 0 ) {
-				continue;
-			}
-
-			// Convert context key to request parameter key.
-			$param_key = str_replace( $prefix, '', $key );
-
-			// Skip keys we already handle in the main function.
-			if ( in_array( $param_key, array( 'maxPages', 'content_source', 'items_count' ), true ) ) {
-				continue;
-			}
-
-			$request_data[ $param_key ] = $value;
+		if ( empty( $options ) ) {
+			return 1;
 		}
 
-		return $request_data;
+		// The filter narrows the query, so it is part of the identity here.
+		$cache_key = md5( (string) wp_json_encode( array( $options, Visual_Portfolio_Get::get_filter_active_item( array() ) ) ) );
+
+		if ( ! isset( self::$max_pages_cache[ $cache_key ] ) ) {
+			self::$max_pages_cache[ $cache_key ] = Visual_Portfolio_Get::calculate_max_pages( $options );
+		}
+
+		return self::$max_pages_cache[ $cache_key ];
 	}
 
 	/**
@@ -116,7 +94,8 @@ class Visual_Portfolio_Block_Paged_Pagination {
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
 				'class'      => 'vp-block-pagination',
-				'aria-label' => esc_attr__( 'Pagination', 'visual-portfolio' ),
+				// `get_block_wrapper_attributes()` escapes the values itself.
+				'aria-label' => __( 'Pagination', 'visual-portfolio' ),
 			)
 		);
 

--- a/gutenberg/blocks/pagination/style.scss
+++ b/gutenberg/blocks/pagination/style.scss
@@ -40,8 +40,13 @@
 
 // Fill style.
 .vp-block-pagination.is-style-fill {
+	// Every button-like trigger gets the same pill, including Load More and the
+	// Infinite trigger - without them the style did nothing at all on a loop
+	// that uses one of those instead of paged links.
 	.vp-block-pagination-next,
-	.vp-block-pagination-previous {
+	.vp-block-pagination-previous,
+	.vp-block-pagination-load-more,
+	.vp-block-pagination-infinite {
 		border-radius: 9999px;
 		padding: 0.3em 0.8em;
 		background-color: color-mix(in srgb, currentColor 7%, transparent);

--- a/gutenberg/blocks/pagination/style.scss
+++ b/gutenberg/blocks/pagination/style.scss
@@ -39,7 +39,7 @@
 }
 
 // Fill style.
-.is-style-fill {
+.vp-block-pagination.is-style-fill {
 	.vp-block-pagination-next,
 	.vp-block-pagination-previous {
 		border-radius: 9999px;

--- a/gutenberg/blocks/pagination/variations.js
+++ b/gutenberg/blocks/pagination/variations.js
@@ -8,9 +8,11 @@ export default [
 	{
 		name: 'paged',
 		scope: ['inserter', 'block'],
-		title: __('Pagination Paged (Experimental)'),
-		description:
+		title: __('Pagination Paged (Experimental)', 'visual-portfolio'),
+		description: __(
 			'Displays paged pagination for Gallery Loop. Block is experimental and will change in future releases. Please use with caution.',
+			'visual-portfolio'
+		),
 		attributes: {
 			layout: { type: 'flex', justifyContent: 'space-between' },
 		},
@@ -27,9 +29,11 @@ export default [
 	{
 		name: 'load-more',
 		scope: ['inserter', 'block'],
-		title: __('Pagination Load More (Experimental)'),
-		description:
+		title: __('Pagination Load More (Experimental)', 'visual-portfolio'),
+		description: __(
 			'Displays a load more button for pagination. Block is experimental and will change in future releases. Please use with caution.',
+			'visual-portfolio'
+		),
 		attributes: { layout: { type: 'flex', justifyContent: 'center' } },
 		innerBlocks: [['visual-portfolio/pagination-load-more']],
 		icon: {
@@ -40,9 +44,11 @@ export default [
 	{
 		name: 'infinite',
 		scope: ['inserter', 'block'],
-		title: __('Pagination Infinite (Experimental)'),
-		description:
-			'Displays a infinite scroll pagination. Block is experimental and will change in future releases. Please use with caution.',
+		title: __('Pagination Infinite (Experimental)', 'visual-portfolio'),
+		description: __(
+			'Displays an infinite scroll pagination. Block is experimental and will change in future releases. Please use with caution.',
+			'visual-portfolio'
+		),
 		attributes: { layout: { type: 'flex', justifyContent: 'center' } },
 		innerBlocks: [['visual-portfolio/pagination-infinite']],
 		icon: {

--- a/gutenberg/blocks/pagination/view.js
+++ b/gutenberg/blocks/pagination/view.js
@@ -45,25 +45,32 @@ const infiniteObserver = new window.IntersectionObserver(
 				return;
 			}
 
-			// The trigger is replaced with a fresh one after each load.
-			if (!target.isConnected) {
-				observer.unobserve(target);
-				return;
+			// Contained per entry, so one failing trigger does not stop the
+			// other loops reported in the same batch.
+			try {
+				// The trigger is replaced with a fresh one after each load.
+				if (!target.isConnected) {
+					observer.unobserve(target);
+					return;
+				}
+
+				const href = target.getAttribute('href');
+
+				// Nothing left to load.
+				if (!href) {
+					observer.unobserve(target);
+					return;
+				}
+
+				if (!entry.isIntersecting) {
+					return;
+				}
+
+				getLoopGallery(target)?.loadNewItems(href, false);
+			} catch (error) {
+				// eslint-disable-next-line no-console -- we have to log errors.
+				console.error(error);
 			}
-
-			const href = target.getAttribute('href');
-
-			// Nothing left to load.
-			if (!href) {
-				observer.unobserve(target);
-				return;
-			}
-
-			if (!entry.isIntersecting) {
-				return;
-			}
-
-			getLoopGallery(target)?.loadNewItems(href, false);
 		});
 	},
 	{ rootMargin: '300px 0px' }

--- a/gutenberg/blocks/pagination/view.js
+++ b/gutenberg/blocks/pagination/view.js
@@ -1,22 +1,11 @@
 import $ from 'jquery';
 import { throttle } from 'lodash';
 
+import { getLoopGallery } from '../../utils/loop-gallery';
+
 const $doc = $(document);
 
 const INFINITE_SELECTOR = '.vp-block-pagination-infinite';
-
-/**
- * Get the gallery instance the given loop control belongs to.
- *
- * @param {Element} element - control inside `.vp-block-loop`.
- * @return {Object|undefined} gallery instance.
- */
-function getLoopGallery(element) {
-	const loop = element.closest('.vp-block-loop');
-	const legacyBlock = loop?.querySelector('.vp-portfolio');
-
-	return legacyBlock?.vpf;
-}
 
 $doc.on(
 	'click',

--- a/gutenberg/blocks/pagination/view.js
+++ b/gutenberg/blocks/pagination/view.js
@@ -3,14 +3,27 @@ import { throttle } from 'lodash';
 
 const $doc = $(document);
 
+const INFINITE_SELECTOR = '.vp-block-pagination-infinite';
+
+/**
+ * Get the gallery instance the given loop control belongs to.
+ *
+ * @param {Element} element - control inside `.vp-block-loop`.
+ * @return {Object|undefined} gallery instance.
+ */
+function getLoopGallery(element) {
+	const loop = element.closest('.vp-block-loop');
+	const legacyBlock = loop?.querySelector('.vp-portfolio');
+
+	return legacyBlock?.vpf;
+}
+
 $doc.on(
 	'click',
 	'.vp-block-pagination-previous, .vp-block-pagination-next, .vp-block-pagination-numbers a, .vp-block-pagination-load-more, .vp-block-pagination-infinite',
 	(e) => {
 		const $current = $(e.currentTarget);
-		const $loop = $current.closest('.vp-block-loop');
-		const $legacyBlock = $loop.find('.vp-portfolio');
-		const vpf = $legacyBlock?.[0]?.vpf;
+		const vpf = getLoopGallery(e.currentTarget);
 
 		if (!vpf) {
 			return;
@@ -29,86 +42,59 @@ $doc.on(
 
 /**
  * Infinite scroll.
+ *
+ * The observer reports the initial intersection state right after `observe()`,
+ * so re-registering the trigger once the new markup arrives is enough to keep
+ * loading while it stays in view.
  */
-$doc.on('loadedNewItems.vpf', (event, vpObject) => {
-	if ('vpf' !== event.namespace) {
-		return;
-	}
-
-	if (!vpObject.$item.find('vp-block-pagination-infinite').length) {
-		return;
-	}
-
-	// Infinite pagination should start loading again in case the pagination is still in view.
-	// Use setTimeout to allow DOM to settle after content insertion
-	setTimeout(() => {
-		const $infinitePagination = vpObject.$item.find(
-			'.vp-block-pagination-infinite.is-intersecting:first'
-		);
-
-		if ($infinitePagination.length && $infinitePagination.attr('href')) {
-			vpObject.loadNewItems($infinitePagination.attr('href'), false);
-		}
-	}, 100);
-});
-
 const infiniteObserver = new window.IntersectionObserver(
 	(entries, observer) => {
-		try {
-			entries.forEach((entry) => {
-				if (!entry.target) {
-					return;
-				}
+		entries.forEach((entry) => {
+			const { target } = entry;
 
-				const href = entry.target.getAttribute('href');
+			if (!target) {
+				return;
+			}
 
-				// Disconnect observer when no href.
-				if (!href) {
-					observer.disconnect();
-					return;
-				}
+			// The trigger is replaced with a fresh one after each load.
+			if (!target.isConnected) {
+				observer.unobserve(target);
+				return;
+			}
 
-				if (entry.isIntersecting) {
-					// Mark as intersecting and trigger loading
-					entry.target.classList.add('is-intersecting');
+			const href = target.getAttribute('href');
 
-					const loop = entry.target.closest('.vp-block-loop');
-					const legacyBlock = loop?.querySelector('.vp-portfolio');
-					const vpf = legacyBlock?.vpf;
+			// Nothing left to load.
+			if (!href) {
+				observer.unobserve(target);
+				return;
+			}
 
-					if (vpf) {
-						vpf.loadNewItems(href, false);
-					}
-				} else {
-					// Remove intersecting marker when out of view
-					entry.target.classList.remove('is-intersecting');
-				}
-			});
-		} catch (error) {
-			// eslint-disable-next-line no-console -- we have to log errors.
-			console.log(error);
-		}
+			if (!entry.isIntersecting) {
+				return;
+			}
+
+			getLoopGallery(target)?.loadNewItems(href, false);
+		});
 	},
 	{ rootMargin: '300px 0px' }
 );
 
-const initInfiniteThrottled = throttle(() => {
+const initInfinite = throttle(() => {
 	document
-		.querySelectorAll(
-			'.vp-block-pagination-infinite[href]:not(.is-handled)'
-		)
+		.querySelectorAll(`${INFINITE_SELECTOR}[href]:not(.is-handled)`)
 		.forEach((element) => {
 			element.classList.add('is-handled');
 			infiniteObserver.observe(element);
 		});
 }, 200);
 
-$doc.on('ready', () => {
-	new window.MutationObserver(initInfiniteThrottled).observe(
-		document.documentElement,
-		{
-			childList: true,
-			subtree: true,
-		}
-	);
-});
+// This is a footer script, but `$( fn )` also fires immediately when the
+// document is already ready.
+$(initInfinite);
+
+// Pagination blocks are replaced with new markup after AJAX loading.
+$doc.on('replacedLoopBlocks.vpf', initInfinite);
+
+// Galleries may be initialized later than this script runs.
+$doc.on('init.vpf', initInfinite);

--- a/gutenberg/blocks/sort/index.php
+++ b/gutenberg/blocks/sort/index.php
@@ -40,58 +40,38 @@ class Visual_Portfolio_Block_Sort {
 	/**
 	 * Block output
 	 *
-	 * @param array  $attributes - block attributes.
-	 * @param string $content - block content.
+	 * The options are the same for every sort block, so neither the attributes
+	 * nor the inner content are used.
 	 *
 	 * @return string
 	 */
-	public function block_render( $attributes, $content ) {
+	public function block_render() {
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
 				'class' => 'vp-block-sort',
 			)
 		);
 
-		$content = '';
-
-		$sort_items = array(
-			''           => esc_html__( 'Default sorting', 'visual-portfolio' ),
-			'date_desc'  => esc_html__( 'Sort by date (newest)', 'visual-portfolio' ),
-			'date'       => esc_html__( 'Sort by date (oldest)', 'visual-portfolio' ),
-			'title'      => esc_html__( 'Sort by title (A-Z)', 'visual-portfolio' ),
-			'title_desc' => esc_html__( 'Sort by title (Z-A)', 'visual-portfolio' ),
-		);
+		$options = '';
 
 		// Get active item.
-		$active_item = false;
+		$active_item = Visual_Portfolio_Get::get_current_sort();
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['vp_sort'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$active_item = sanitize_text_field( wp_unslash( $_GET['vp_sort'] ) );
-		}
-
-		foreach ( $sort_items as $slug => $label ) {
-			$url = Visual_Portfolio_Get::get_pagenum_link(
-				array(
-					'vp_sort' => rawurlencode( $slug ),
-					'vp_page' => 1,
-				)
-			);
+		foreach ( Visual_Portfolio_Get::get_sort_items() as $slug => $label ) {
+			$url = Visual_Portfolio_Get::get_sort_item_url( $slug );
 
 			$is_active = ! $active_item && ! $slug ? true : $active_item === $slug;
 
-			$content .= '<option data-vp-url="' . esc_url( $url ) . '" value="' . esc_attr( $slug ) . '" ' . selected( $is_active, true, false ) . '>';
-			$content .= esc_html( $label );
-			$content .= '</option>';
+			$options .= '<option data-vp-url="' . esc_url( $url ) . '" value="' . esc_attr( $slug ) . '" ' . selected( $is_active, true, false ) . '>';
+			$options .= esc_html( $label );
+			$options .= '</option>';
 		}
 
-		$content = '<select>' . $content . '</select>';
-
 		return sprintf(
-			'<div %1$s>%2$s</div>',
+			'<div %1$s><select aria-label="%2$s">%3$s</select></div>',
 			$wrapper_attributes,
-			$content
+			esc_attr__( 'Sort items', 'visual-portfolio' ),
+			$options
 		);
 	}
 }

--- a/gutenberg/blocks/sort/view.js
+++ b/gutenberg/blocks/sort/view.js
@@ -1,12 +1,12 @@
 import $ from 'jquery';
 
+import { getLoopGallery } from '../../utils/loop-gallery';
+
 const $doc = $(document);
 
 $doc.on('change', '.vp-block-sort select', (e) => {
 	const $current = $(e.currentTarget);
-	const $loop = $current.closest('.vp-block-loop');
-	const $legacyBlock = $loop.find('.vp-portfolio');
-	const vpf = $legacyBlock?.[0]?.vpf;
+	const vpf = getLoopGallery(e.currentTarget);
 
 	if (!vpf) {
 		return;

--- a/gutenberg/components/iframe-preview/index.js
+++ b/gutenberg/components/iframe-preview/index.js
@@ -59,10 +59,13 @@ class IframePreview extends Component {
 		this.maybeAttributesChanged = this.maybeAttributesChanged.bind(this);
 		this.onFrameLoad = this.onFrameLoad.bind(this);
 		this.maybeReload = this.maybeReload.bind(this);
-		this.maybeReloadDebounce = debounce(
-			300,
-			rafSchd(this.maybeReload.bind(this))
-		);
+		// No `rafSchd` here. Reloading only sets state and submits a form, so it
+		// has nothing to coalesce into a frame that `debounce` does not already
+		// coalesce - and `raf-schd` keeps its pending frame id until the frame
+		// runs, so one frame that never comes (a hidden editor canvas, a
+		// backgrounded tab that gets discarded) silently stops every later
+		// reload for the rest of the session.
+		this.maybeReloadDebounce = debounce(300, this.maybeReload.bind(this));
 		this.maybeResizePreviews = this.maybeResizePreviews.bind(this);
 		this.maybeResizePreviewsThrottle = throttle(
 			100,

--- a/gutenberg/utils/convert-legacy-attributes/index.php
+++ b/gutenberg/utils/convert-legacy-attributes/index.php
@@ -5,6 +5,10 @@
  * @package visual-portfolio
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Visual_Portfolio_Convert_Attributes
  */
@@ -157,7 +161,15 @@ class Visual_Portfolio_Convert_Attributes {
 		// Merge with defaults if include_defaults is true.
 		$attributes_to_convert = $modern_attributes;
 		if ( $include_defaults ) {
-			$attributes_to_convert = array_merge( self::$modern_defaults, $modern_attributes );
+			// Merge one level deep, so a partially set group keeps the defaults
+			// of the keys it does not carry.
+			foreach ( self::$modern_defaults as $key => $default_value ) {
+				$value = $modern_attributes[ $key ] ?? null;
+
+				$attributes_to_convert[ $key ] = is_array( $value )
+					? array_merge( $default_value, $value )
+					: $default_value;
+			}
 		}
 
 		// Handle direct mappings.

--- a/gutenberg/utils/loop-controls/index.js
+++ b/gutenberg/utils/loop-controls/index.js
@@ -1,0 +1,28 @@
+const { controls: registeredControls } = window.VPGutenbergVariables;
+
+/**
+ * General settings the Gallery Loop block owns.
+ *
+ * The loop only describes the query, so it keeps the settings that shape it.
+ * Everything else in the `content-source-general` category is a rendering
+ * setting of the gallery block inside the loop - the loop has no attribute to
+ * store them in, and no markup to apply them to.
+ *
+ * @type {string[]}
+ */
+export const LOOP_GENERAL_CONTROLS = ['items_count'];
+
+/**
+ * Take a subset of the registered controls, keyed the same way.
+ *
+ * @param {string[]} names   - control names.
+ * @param {boolean}  exclude - return everything except the given names.
+ * @return {Object} controls.
+ */
+export function pickControls(names, exclude = false) {
+	return Object.fromEntries(
+		Object.entries(registeredControls).filter(
+			([name]) => names.includes(name) !== exclude
+		)
+	);
+}

--- a/gutenberg/utils/loop-gallery/index.js
+++ b/gutenberg/utils/loop-gallery/index.js
@@ -1,0 +1,24 @@
+/**
+ * Get the gallery instance a Gallery Loop control belongs to.
+ *
+ * Loops can be nested, so the first `.vp-portfolio` inside the closest loop is
+ * not necessarily the one that loop owns - it can belong to a nested loop that
+ * comes first in document order. Only a gallery whose own nearest loop is this
+ * loop is driven by this control.
+ *
+ * @param {Element} element - control inside `.vp-block-loop`.
+ * @return {Object|undefined} gallery instance.
+ */
+export function getLoopGallery(element) {
+	const loop = element?.closest('.vp-block-loop');
+
+	if (!loop) {
+		return undefined;
+	}
+
+	const gallery = Array.from(loop.querySelectorAll('.vp-portfolio')).find(
+		(candidate) => candidate.closest('.vp-block-loop') === loop
+	);
+
+	return gallery?.vpf;
+}

--- a/tests/e2e/specs/gallery-loop-blocks.spec.js
+++ b/tests/e2e/specs/gallery-loop-blocks.spec.js
@@ -1,0 +1,278 @@
+/**
+ * Gallery Loop blocks: filter, sort and pagination.
+ *
+ * These blocks read the query from the loop context and resolve their links and
+ * page counts on every request, so the assertions here deliberately check the
+ * frontend markup rather than what the editor stored.
+ */
+import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+
+import { createRegularPosts } from '../utils/create-posts';
+import { openPublishedPage } from '../utils/open-published-page';
+import { getPluginSlug } from '../utils/plugin-slug';
+
+const PER_PAGE = 3;
+const POSTS_COUNT = 7;
+const CATEGORIES = ['Loop Nature', 'Loop City'];
+
+/**
+ * Build a Gallery Loop block with the given pagination children.
+ *
+ * @param {Array} paginationBlocks - inner blocks of the pagination block.
+ * @return {Object} block payload for `editor.insertBlock()`.
+ */
+function getLoopBlock(paginationBlocks) {
+	return {
+		name: 'visual-portfolio/loop',
+		attributes: {
+			queryType: 'posts',
+			baseQuery: { perPage: PER_PAGE, maxPages: 1 },
+			postsQuery: {
+				source: 'post',
+				order: 'desc',
+				orderBy: 'post_date',
+			},
+		},
+		innerBlocks: [
+			{ name: 'visual-portfolio/filter-by-category' },
+			{
+				name: 'visual-portfolio/block',
+				attributes: { setup_wizard: 'false' },
+			},
+			{
+				name: 'visual-portfolio/pagination',
+				innerBlocks: paginationBlocks,
+			},
+		],
+	};
+}
+
+const PAGED_PAGINATION = [
+	{ name: 'visual-portfolio/pagination-previous' },
+	{ name: 'visual-portfolio/pagination-numbers' },
+	{ name: 'visual-portfolio/pagination-next' },
+];
+
+test.describe('Gallery Loop blocks', () => {
+	test.beforeAll(async ({ requestUtils }) => {
+		await requestUtils.activatePlugin(getPluginSlug());
+		await requestUtils.deleteAllPosts();
+
+		await createRegularPosts({
+			requestUtils,
+			count: POSTS_COUNT,
+			categories: CATEGORIES,
+		});
+	});
+
+	test.afterAll(async ({ requestUtils }) => {
+		await Promise.all([
+			requestUtils.deleteAllPages(),
+			requestUtils.deleteAllPosts(),
+		]);
+	});
+
+	test('filter items are fetched when the loop is inserted', async ({
+		admin,
+		editor,
+	}) => {
+		await admin.createNewPost({
+			title: 'Gallery Loop - filter items',
+			postType: 'page',
+			showWelcomeGuide: false,
+			legacyCanvas: true,
+		});
+
+		await editor.insertBlock(getLoopBlock(PAGED_PAGINATION));
+
+		// The filter block asks the REST API for the terms behind the query, so
+		// a freshly inserted loop must end up with more than just the "All" item.
+		await expect
+			.poll(async () => getFilterItemCount(await editor.getBlocks()), {
+				timeout: 20000,
+			})
+			.toBe(CATEGORIES.length + 1);
+	});
+
+	test('category links point at the published page and filter its items', async ({
+		page,
+		admin,
+		editor,
+	}) => {
+		await admin.createNewPost({
+			title: 'Gallery Loop - filtering',
+			postType: 'page',
+			showWelcomeGuide: false,
+			legacyCanvas: true,
+		});
+
+		await editor.insertBlock(getLoopBlock(PAGED_PAGINATION));
+		await editor.publishPost();
+
+		const frontend = await openPublishedPage(page);
+		const pageUrl = new URL(frontend.url());
+
+		const items = frontend.locator('.vp-block-filter-by-category-item');
+		await expect(items.first()).toBeVisible();
+
+		// "All" is rendered as a non-link span while it is the active item.
+		await expect(
+			frontend.locator('span.vp-block-filter-by-category-item.is-active')
+		).toHaveCount(1);
+
+		// Only the categories are links while "All" is active.
+		const categoryLink = frontend
+			.locator('a.vp-block-filter-by-category-item')
+			.first();
+		const href = await categoryLink.getAttribute('href');
+		const label = (await categoryLink.innerText()).trim();
+
+		// The URL is built at render time from the page being viewed, and posts
+		// are filtered by `taxonomy:slug`.
+		expect(href).toContain(pageUrl.pathname);
+		expect(href).toContain('vp_filter=category%3A');
+
+		await categoryLink.click();
+
+		// The filter markup is replaced with the one of the filtered page, where
+		// the clicked category became the active item.
+		await expect(
+			frontend.locator('span.vp-block-filter-by-category-item.is-active')
+		).toHaveText(label, { timeout: 15000 });
+	});
+
+	test('paged pagination walks the pages and hides its edge links', async ({
+		page,
+		admin,
+		editor,
+	}) => {
+		await admin.createNewPost({
+			title: 'Gallery Loop - paged',
+			postType: 'page',
+			showWelcomeGuide: false,
+			legacyCanvas: true,
+		});
+
+		await editor.insertBlock(getLoopBlock(PAGED_PAGINATION));
+		await editor.publishPost();
+
+		const frontend = await openPublishedPage(page);
+
+		const expectedPages = Math.ceil(POSTS_COUNT / PER_PAGE);
+		const numbers = frontend.locator('.vp-block-pagination-numbers > *');
+
+		await expect(numbers.first()).toBeVisible();
+		await expect(numbers).toHaveCount(expectedPages);
+
+		// No "previous" link on the first page.
+		await expect(
+			frontend.locator('.vp-block-pagination-previous')
+		).toHaveCount(0);
+
+		await frontend.locator('.vp-block-pagination-next').click();
+
+		// The pagination markup is replaced with the one of the loaded page.
+		await expect(
+			frontend.locator('.vp-block-pagination-previous')
+		).toHaveCount(1);
+
+		// Walk to the last page - "next" must be gone there.
+		for (let i = 2; i < expectedPages; i++) {
+			await frontend.locator('.vp-block-pagination-next').click();
+			await expect(
+				frontend.locator('.vp-block-pagination-numbers .is-active')
+			).toHaveText(String(i + 1));
+		}
+
+		await expect(frontend.locator('.vp-block-pagination-next')).toHaveCount(
+			0
+		);
+	});
+
+	test('load more disappears once the last page is loaded', async ({
+		page,
+		admin,
+		editor,
+	}) => {
+		await admin.createNewPost({
+			title: 'Gallery Loop - load more',
+			postType: 'page',
+			showWelcomeGuide: false,
+			legacyCanvas: true,
+		});
+
+		await editor.insertBlock(
+			getLoopBlock([{ name: 'visual-portfolio/pagination-load-more' }])
+		);
+		await editor.publishPost();
+
+		const frontend = await openPublishedPage(page);
+
+		const loadMore = frontend.locator('.vp-block-pagination-load-more');
+		const items = frontend.locator('.vp-portfolio__item');
+
+		await expect(loadMore).toHaveCount(1);
+		await expect(items).toHaveCount(PER_PAGE);
+
+		const clicks = Math.ceil(POSTS_COUNT / PER_PAGE) - 1;
+
+		for (let i = 1; i <= clicks; i++) {
+			await loadMore.click();
+
+			await expect(items).toHaveCount(
+				Math.min(POSTS_COUNT, PER_PAGE * (i + 1))
+			);
+		}
+
+		// Everything is loaded, so there is nothing left to click.
+		await expect(loadMore).toHaveCount(0);
+	});
+
+	test('page count follows the content without re-saving the page', async ({
+		page,
+		admin,
+		editor,
+		requestUtils,
+	}) => {
+		await admin.createNewPost({
+			title: 'Gallery Loop - stale max pages',
+			postType: 'page',
+			showWelcomeGuide: false,
+			legacyCanvas: true,
+		});
+
+		await editor.insertBlock(getLoopBlock(PAGED_PAGINATION));
+		await editor.publishPost();
+
+		const frontend = await openPublishedPage(page);
+		const publishedUrl = frontend.url();
+
+		const numbers = frontend.locator('.vp-block-pagination-numbers > *');
+		await expect(numbers).toHaveCount(Math.ceil(POSTS_COUNT / PER_PAGE));
+
+		// Publishing more posts must add a page, even though the page itself was
+		// not touched - the count is calculated per request, not stored.
+		await createRegularPosts({ requestUtils, count: PER_PAGE });
+
+		await frontend.goto(publishedUrl);
+
+		await expect(numbers).toHaveCount(
+			Math.ceil((POSTS_COUNT + PER_PAGE) / PER_PAGE)
+		);
+	});
+});
+
+/**
+ * Count the filter items inside the inserted loop block.
+ *
+ * @param {Array} blocks - editor blocks.
+ * @return {number} number of filter items.
+ */
+function getFilterItemCount(blocks) {
+	const loop = blocks.find((block) => 'visual-portfolio/loop' === block.name);
+	const filter = loop?.innerBlocks?.find(
+		(block) => 'visual-portfolio/filter-by-category' === block.name
+	);
+
+	return filter?.innerBlocks?.length ?? 0;
+}

--- a/tests/e2e/specs/gallery-loop-blocks.spec.js
+++ b/tests/e2e/specs/gallery-loop-blocks.spec.js
@@ -53,23 +53,53 @@ const PAGED_PAGINATION = [
 	{ name: 'visual-portfolio/pagination-next' },
 ];
 
+/**
+ * Count the published posts the loop query will see.
+ *
+ * @param {Object} requestUtils - REST utils.
+ * @return {Promise<number>} number of published posts.
+ */
+async function getPublishedPostCount(requestUtils) {
+	const posts = await requestUtils.rest({
+		path: '/wp/v2/posts',
+		params: { per_page: 100, status: 'publish' },
+	});
+
+	return posts.length;
+}
+
 test.describe('Gallery Loop blocks', () => {
+	// Resetting posts globally is `global-setup.js`'s job, so this spec works
+	// with whatever else is published and cleans up only what it created.
+	let createdPostIds = [];
+	let totalPosts = 0;
+	let expectedPages = 0;
+
 	test.beforeAll(async ({ requestUtils }) => {
 		await requestUtils.activatePlugin(getPluginSlug());
-		await requestUtils.deleteAllPosts();
 
-		await createRegularPosts({
+		createdPostIds = await createRegularPosts({
 			requestUtils,
 			count: POSTS_COUNT,
 			categories: CATEGORIES,
 		});
+
+		totalPosts = await getPublishedPostCount(requestUtils);
+		expectedPages = Math.ceil(totalPosts / PER_PAGE);
 	});
 
 	test.afterAll(async ({ requestUtils }) => {
-		await Promise.all([
-			requestUtils.deleteAllPages(),
-			requestUtils.deleteAllPosts(),
-		]);
+		await requestUtils.deleteAllPages();
+
+		await Promise.all(
+			createdPostIds.map((id) =>
+				requestUtils.rest({
+					path: `/wp/v2/posts/${id}`,
+					method: 'DELETE',
+					params: { force: true },
+				})
+			)
+		);
 	});
 
 	test('filter items are fetched when the loop is inserted', async ({
@@ -85,13 +115,15 @@ test.describe('Gallery Loop blocks', () => {
 
 		await editor.insertBlock(getLoopBlock(PAGED_PAGINATION));
 
-		// The filter block asks the REST API for the terms behind the query, so
-		// a freshly inserted loop must end up with more than just the "All" item.
+		// The filter block asks the REST API for the terms behind the query, so a
+		// freshly inserted loop must end up with more than just the "All" item.
+		// Other posts on the site may contribute terms too, so this checks that
+		// the categories are there rather than an exact total.
 		await expect
-			.poll(async () => getFilterItemCount(await editor.getBlocks()), {
+			.poll(async () => getFilterItemLabels(await editor.getBlocks()), {
 				timeout: 20000,
 			})
-			.toBe(CATEGORIES.length + 1);
+			.toEqual(expect.arrayContaining(['All', ...CATEGORIES]));
 	});
 
 	test('category links point at the published page and filter its items', async ({
@@ -158,7 +190,6 @@ test.describe('Gallery Loop blocks', () => {
 
 		const frontend = await openPublishedPage(page);
 
-		const expectedPages = Math.ceil(POSTS_COUNT / PER_PAGE);
 		const numbers = frontend.locator('.vp-block-pagination-numbers > *');
 
 		await expect(numbers.first()).toBeVisible();
@@ -214,13 +245,11 @@ test.describe('Gallery Loop blocks', () => {
 		await expect(loadMore).toHaveCount(1);
 		await expect(items).toHaveCount(PER_PAGE);
 
-		const clicks = Math.ceil(POSTS_COUNT / PER_PAGE) - 1;
-
-		for (let i = 1; i <= clicks; i++) {
+		for (let i = 1; i <= expectedPages - 1; i++) {
 			await loadMore.click();
 
 			await expect(items).toHaveCount(
-				Math.min(POSTS_COUNT, PER_PAGE * (i + 1))
+				Math.min(totalPosts, PER_PAGE * (i + 1))
 			);
 		}
 
@@ -248,31 +277,33 @@ test.describe('Gallery Loop blocks', () => {
 		const publishedUrl = frontend.url();
 
 		const numbers = frontend.locator('.vp-block-pagination-numbers > *');
-		await expect(numbers).toHaveCount(Math.ceil(POSTS_COUNT / PER_PAGE));
+		await expect(numbers).toHaveCount(expectedPages);
 
 		// Publishing more posts must add a page, even though the page itself was
 		// not touched - the count is calculated per request, not stored.
-		await createRegularPosts({ requestUtils, count: PER_PAGE });
+		const extraIds = await createRegularPosts({
+			requestUtils,
+			count: PER_PAGE,
+		});
+		createdPostIds = createdPostIds.concat(extraIds);
 
 		await frontend.goto(publishedUrl);
 
-		await expect(numbers).toHaveCount(
-			Math.ceil((POSTS_COUNT + PER_PAGE) / PER_PAGE)
-		);
+		await expect(numbers).toHaveCount(expectedPages + 1);
 	});
 });
 
 /**
- * Count the filter items inside the inserted loop block.
+ * Read the filter item labels inside the inserted loop block.
  *
  * @param {Array} blocks - editor blocks.
- * @return {number} number of filter items.
+ * @return {string[]} filter item labels.
  */
-function getFilterItemCount(blocks) {
+function getFilterItemLabels(blocks) {
 	const loop = blocks.find((block) => 'visual-portfolio/loop' === block.name);
 	const filter = loop?.innerBlocks?.find(
 		(block) => 'visual-portfolio/filter-by-category' === block.name
 	);
 
-	return filter?.innerBlocks?.length ?? 0;
+	return (filter?.innerBlocks ?? []).map((block) => block.attributes.text);
 }

--- a/tests/e2e/utils/create-posts.js
+++ b/tests/e2e/utils/create-posts.js
@@ -21,22 +21,22 @@ export async function createRegularPosts({
 	// Create categories if provided
 	const categoryIds = [];
 	for (const categoryName of categories) {
+		const slug = categoryName.toLowerCase().replace(/\s+/g, '-');
+
 		try {
 			const category = await requestUtils.rest({
 				path: '/wp/v2/categories',
 				method: 'POST',
-				data: {
-					name: categoryName,
-					slug: categoryName.toLowerCase().replace(/\s+/g, '-'),
-				},
+				data: { name: categoryName, slug },
 			});
 			categoryIds.push(category.id);
 		} catch (_error) {
-			// Category might already exist
+			// Category might already exist. The query has to go through
+			// `params`: the REST root URL already carries a query string, so a
+			// `?` in the path ends up inside the `rest_route` parameter.
 			const existingCategories = await requestUtils.rest({
-				path: `/wp/v2/categories?slug=${categoryName
-					.toLowerCase()
-					.replace(/\s+/g, '-')}`,
+				path: '/wp/v2/categories',
+				params: { slug },
 			});
 			if (existingCategories && existingCategories.length > 0) {
 				categoryIds.push(existingCategories[0].id);

--- a/tests/e2e/utils/open-published-page.js
+++ b/tests/e2e/utils/open-published-page.js
@@ -14,6 +14,24 @@ export async function openPublishedPage(page, options = {}) {
 		.locator('.components-button', { hasText: 'View Page' })
 		.first();
 
+	// The post-publish panel can be dismissed by the time we get here, and the
+	// snackbar goes away on its own. Navigating to the permalink is equivalent.
+	if (!(await viewButton.isVisible())) {
+		const permalink = await page.evaluate(
+			() => window.wp?.data?.select('core/editor')?.getPermalink() || ''
+		);
+
+		if (!permalink) {
+			throw new Error(
+				'Could not find the published page: no "View Page" button and no permalink.'
+			);
+		}
+
+		await page.goto(permalink, { waitUntil: 'domcontentloaded' });
+
+		return page;
+	}
+
 	const popupPromise = page
 		.waitForEvent('popup', { timeout })
 		.catch(() => null);

--- a/tests/phpunit/unit/test-class-get-portfolio-max-pages.php
+++ b/tests/phpunit/unit/test-class-get-portfolio-max-pages.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Tests for Visual_Portfolio_Get::calculate_max_pages
+ *
+ * @package Visual Portfolio
+ */
+
+/**
+ * Max pages test case.
+ */
+class ClassGetPortfolioMaxPages extends WP_UnitTestCase {
+	/**
+	 * Clean up the request between tests.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		unset( $_GET['vp_filter'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Build legacy options the same way the Gallery Loop block does.
+	 *
+	 * @param string $query_type - modern content source.
+	 * @param int    $per_page - items per page.
+	 * @param array  $query - `postsQuery` or `imagesQuery` overrides.
+	 *
+	 * @return array
+	 */
+	private function get_options( $query_type, $per_page, $query = array() ) {
+		$group = 'images' === $query_type ? 'imagesQuery' : 'postsQuery';
+
+		return Visual_Portfolio_Convert_Attributes::modern_to_legacy(
+			array(
+				'queryType' => $query_type,
+				'baseQuery' => array( 'perPage' => $per_page ),
+				$group      => $query,
+			),
+			true
+		);
+	}
+
+	/**
+	 * Build the image items the `images` content source expects.
+	 *
+	 * @param int    $count - number of images.
+	 * @param string $category - category assigned to every image.
+	 *
+	 * @return array
+	 */
+	private function get_images( $count, $category = '' ) {
+		$images = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$images[] = array(
+				'id'         => $i + 1,
+				'categories' => $category ? array( $category ) : array(),
+			);
+		}
+
+		return $images;
+	}
+
+	/**
+	 * A query that fits on one page reports a single page.
+	 *
+	 * @return void
+	 */
+	public function test_single_page() {
+		$max_pages = Visual_Portfolio_Get::calculate_max_pages(
+			$this->get_options( 'images', 6, array( 'images' => $this->get_images( 4 ) ) )
+		);
+
+		$this->assertSame( 1, $max_pages );
+	}
+
+	/**
+	 * Images are split into pages of `items_count`.
+	 *
+	 * @return void
+	 */
+	public function test_images_are_paged() {
+		$max_pages = Visual_Portfolio_Get::calculate_max_pages(
+			$this->get_options( 'images', 4, array( 'images' => $this->get_images( 10 ) ) )
+		);
+
+		$this->assertSame( 3, $max_pages );
+	}
+
+	/**
+	 * Images may arrive as a JSON encoded string.
+	 *
+	 * @return void
+	 */
+	public function test_images_as_json_string() {
+		$options           = $this->get_options( 'images', 2, array( 'images' => array() ) );
+		$options['images'] = wp_json_encode( $this->get_images( 5 ) );
+
+		$this->assertSame( 3, Visual_Portfolio_Get::calculate_max_pages( $options ) );
+	}
+
+	/**
+	 * Posts are counted with a real query, and the count follows the content.
+	 *
+	 * This is what makes the pagination blocks correct without re-saving the
+	 * post they live in.
+	 *
+	 * @return void
+	 */
+	public function test_posts_are_paged() {
+		self::factory()->post->create_many( 7 );
+
+		$options = $this->get_options( 'posts', 3, array( 'source' => 'post' ) );
+
+		$this->assertSame( 3, Visual_Portfolio_Get::calculate_max_pages( $options ) );
+
+		// Publishing more posts adds a page, without touching the options.
+		self::factory()->post->create_many( 3 );
+
+		$this->assertSame( 4, Visual_Portfolio_Get::calculate_max_pages( $options ) );
+	}
+
+	/**
+	 * An active `vp_filter` narrows the query, so it changes the page count.
+	 *
+	 * @return void
+	 */
+	public function test_active_filter_is_applied() {
+		$options = $this->get_options(
+			'images',
+			2,
+			array(
+				'images' => array_merge(
+					$this->get_images( 2, 'Nature' ),
+					$this->get_images( 6, 'City' )
+				),
+			)
+		);
+
+		$this->assertSame( 4, Visual_Portfolio_Get::calculate_max_pages( $options ) );
+
+		$_GET['vp_filter'] = Visual_Portfolio_Get::create_slug( 'Nature' );
+
+		$this->assertSame( 1, Visual_Portfolio_Get::calculate_max_pages( $options ) );
+	}
+
+	/**
+	 * Malformed options never divide by zero or report less than one page.
+	 *
+	 * @return void
+	 */
+	public function test_malformed_options() {
+		$options = $this->get_options( 'images', 0, array( 'images' => $this->get_images( 3 ) ) );
+
+		$this->assertSame( 1, Visual_Portfolio_Get::calculate_max_pages( $options ) );
+
+		// No content source at all.
+		$this->assertSame( 1, Visual_Portfolio_Get::calculate_max_pages( array() ) );
+	}
+}


### PR DESCRIPTION
Hardening pass over the experimental Gallery Loop blocks (`loop`, `filter-by-category`,
`filter-by-category-item`, `sort`, `pagination` + its five children) ahead of promoting them.
Refs VPF-34.

The architecture is unchanged: the loop provides `vp/*` context, the children consume it, one
inner block per filter item, and the legacy `visual-portfolio/block` still renders the items.
No change to block markup or to the shape of saved content.

## Broken on the front end

- **Infinite scroll never initialised.** `$doc.on('ready')` binds an event jQuery removed in 3.0,
  so it only fired at all through jQuery Migrate. The handler then installed a MutationObserver
  without an initial pass, so nothing was observed until an unrelated script inserted a node.
  Replaced with an immediate init plus re-registration when the loop swaps in new markup — the
  IntersectionObserver reports the initial intersection state itself, which also removes the need
  for the dead "still in view" handler (it searched for `vp-block-pagination-infinite` without the
  leading dot, from the wrong root).
- **Load More and Infinite stayed on the last page**, where the next-page URL falls back to `#`:
  the button remained clickable and the observer kept treating `#` as a page to load. They now
  carry the same guard `pagination-next` already had.
- **The legacy infinite scroll script shipped on every page of the site** — `store_used_assets()`
  ran from `register_block()` on `init`. Both calls are gone; the new block has its own observer,
  and the load-more handle was never registered anywhere.
- **Gallery CSS landed in the footer for every loop.** `maybe_parse_blocks_from_content()` only
  recognises a gallery whose saved attributes carry `content_source`, and inside a loop that
  arrives through context at render time.

## Stale state baked into post content

- **Filter links.** Each item stored a URL the editor built from `get_permalink( postId )`. In the
  site editor that ID is the template's, a synced pattern linked back to wherever it was last
  edited, and renaming a post left every link stale. The URL is now rebuilt per request from the
  saved `taxonomyId`, the same way `get_posts_terms()` builds it, so URLs stay byte-identical to
  the legacy filter's. Comparing the full `taxonomy:slug` form also fixes two terms sharing a slug
  across taxonomies both lighting up.
- **Page counts.** `max_pages` came from a value the editor stored, which went stale as soon as the
  queried content changed. It is calculated per request now, memoised so the three pagination
  children share one query, and `new Visual_Portfolio_Rest()` is no longer constructed from a
  render path just to reach the calculation.

## Editor

- `useBlockProps` / `useInnerBlocksProps` ran after an early return in the loop's `edit`. It never
  threw only because the condition was unreachable: the component read `preview_image_example`
  while `block.json` declared `previewImageExample` and the example passed a boolean. Fixing the
  name without moving the hooks would have turned this into "Rendered fewer hooks than expected".
- `debounce()` was called during render, so every render built a new closure with its own timeout
  and nothing was ever cancelled — each change fired its own request carrying the whole attributes
  object, every image included.
- Five inspector controls silently did nothing. `ControlsRender` round trips attributes through the
  converter, which keeps only mapped keys, so `setAttributes` discarded `no_items_action`,
  `no_items_notice`, `no_items_action_hide_info`, `stretch` and `custom_css`. Those are rendering
  settings of the gallery block, which the loop was also hiding them from — the loop keeps
  `items_count`, the gallery gets the rest back.
- The filter block's `__timestamp` hack marked the post dirty just from opening it, and its effect
  depended on the block list it wrote to. A freshly inserted loop now fetches its items instead of
  stopping at the template's "All" placeholder, and the first sync only fills in what is missing.
- Filter items can be reordered again — the `lock` default contradicted the parent's `templateLock`.

## Refactors

- `get_current_page_number()` is public and reused by all five pagination blocks; `get_sort_items()`
  and `get_sort_item_url()` restore the `vpf_extend_sort_items` / `vpf_extend_sort_item_url` filters
  the new Sort block had dropped, so Pro and third-party sort options reach it again. Sort labels
  are no longer escaped twice — in the legacy path either.
- `calculate_max_pages()` moved out of the REST controller; the controller delegates, so the
  endpoint behaves the same.
- `modern_to_legacy()` merges attribute groups one level deep like the JS converter, so a partially
  set group keeps the rest of its defaults.
- `.is-style-fill` is scoped to the block instead of matching descendants of any block with that
  class; the sort `<select>` gets an accessible name; AJAX updates are announced through a live
  region.

## Public surface

- New: `vpf_rest_filter_items_source_configs`, so Pro can register filterable sources. An
  unfilterable source returns just the "All" item instead of an error.
- `/get_max_pages/` matches the snake_case of the sibling routes; the old `/get-max-pages/` spelling
  stays registered as an alias.
- `vp/showCount` replaces the long context key, matching the prefix the other contexts use. The old
  key is still provided for one release.

## Tests

Nothing in the suite touched these blocks, so none of these defects were caught anywhere.

- `tests/e2e/specs/gallery-loop-blocks.spec.js` — filter items on insert, category links and
  filtering, paged navigation with its edge links, Load More disappearing at the end, and the page
  count following the content without re-saving.
- `tests/phpunit/unit/test-class-get-portfolio-max-pages.php` — 6 cases for the extracted helper.

Two of the e2e cases were verified by reverting the fix and watching them fail. Two shared helpers
were broken along the way and are fixed here: `create-posts.js` sent its "category already exists"
lookup as a query string inside `path`, which lands inside the `rest_route` parameter and answers
`rest_no_route`, and `open-published-page.js` waited on a snackbar that has usually gone by then.

| | |
|---|---|
| `npm run lint` | clean |
| `npm run lint:php` | clean |
| `npm run test:unit:php` | 129 passed |
| `npm run test:e2e` | 61 passed |

Run against the final state of the branch, not per commit.

## Notes for review

- `build/` is deliberately not in this PR — CI runs `npm run build`, and the committed bundles are
  refreshed at release. Reviewers testing locally need a build first.
- Deliberately left out: the legacy → loop block transform (waits on the new gallery block), and
  removing the loop's now-unused `block_id` / `customCss` / `setupWizard` attributes, which touches
  saved content and needs a deprecation.
- The filter item `count` stays a saved attribute; recomputing it means running the loop query
  again, and `showCount` is off by default.
- `vp_page` / `vp_filter` / `vp_sort` are global query parameters, so two loops on one page still
  paginate together. Pre-existing; per-loop parameters need a stable loop id.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for nested gallery loops, including filtering, sorting, pagination, and asset loading.
  * Added accessible loading and live-update announcements for pagination and loop updates.
  * Added configurable loading labels for pagination controls.
  * Improved category filters with dynamic values, active states, counts, and “All” options.

* **Bug Fixes**
  * Improved infinite scrolling and pagination refresh behavior.
  * Prevented pagination controls from appearing when no additional pages are available.
  * Improved handling of deleted terms, changing result counts, and malformed settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->