### PR TITLE
chore(deps): pick up plugin-toolkit 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"@babel/preset-env": "^7.24.0",
 				"@babel/register": "^7.23.7",
 				"@biomejs/biome": "2.5.7",
-				"@nk-crew/plugin-toolkit": "^0.5.0",
+				"@nk-crew/plugin-toolkit": "^0.5.1",
 				"@playwright/test": "^1.57.0",
 				"@wordpress/e2e-test-utils-playwright": "^1.37.0",
 				"@wordpress/env": "^10.37.0",
@@ -4463,9 +4463,9 @@
 			}
 		},
 		"node_modules/@nk-crew/plugin-toolkit": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.5.0.tgz",
-			"integrity": "sha512-Tfnw/ZmzE7wcWMldBZ73K/fSvtIlZLqLPQuLTSy9yN1cdo/ApJOOilK3e1bvqLNo/uzxLTNHj1U4j4e/DJy3DQ==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.5.1.tgz",
+			"integrity": "sha512-NMNVIZKcwQ6oRu6mSEjpOcme72s6n7f+nzRk9c+rinfjFnr1khB9tZJmLNrjBR1kE1l6FpArXLOWm4nvtZ6Ivg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"@babel/preset-env": "^7.24.0",
 		"@babel/register": "^7.23.7",
 		"@biomejs/biome": "2.5.7",
-		"@nk-crew/plugin-toolkit": "^0.5.0",
+		"@nk-crew/plugin-toolkit": "^0.5.1",
 		"@playwright/test": "^1.57.0",
 		"@wordpress/e2e-test-utils-playwright": "^1.37.0",
 		"@wordpress/env": "^10.37.0",


### PR DESCRIPTION
Picks up [`@nk-crew/plugin-toolkit@0.5.1`](https://github.com/nk-crew/plugin-toolkit/pull/1), which sets `navigationTimeout` in the shared Playwright config.

Playwright Test defaults `navigationTimeout` to `0`, and the `actionTimeout` the toolkit already sets does **not** cover navigations. Left that way, a `goto` or a `waitForURL` that never resolves waits out the entire per-test budget, and the whole budget again on each retry — with no error pointing at where it stuck.

That is not theoretical. It cost lazy-blocks-pro a 4-minute e2e job for weeks: 25 of 26 tests finished in ~1.5 minutes, one hung in a login helper, and the job took 22 minutes — [41 when it missed twice](https://github.com/nk-crew/lazy-blocks-pro/actions/runs/31413831490). Nothing here is hanging today; this is the guardrail so it stays that way.

The range in `package.json` already allowed `0.5.1`, but CI installs with `npm ci` from the lock file, so the lock file has to move for the fix to arrive. Bumping the floor to `^0.5.1` alongside it records why.

No source changes — deps only.