### PR TITLE
perf(e2e): cut repeated setup out of the suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,9 +162,10 @@ jobs:
       - name: Setup Node.js and install dependencies
         uses: ./.github/setup-node
 
-      - name: Npm build
-        run: npm run build
-
+      # No `npm run build` here. `lint:js` is `biome check`, and the shared
+      # Biome config excludes `**/build`; `lint:css` globs the `assets`,
+      # `gutenberg` and `templates` sources directly. Neither reads a single
+      # file the build produces.
       - name: Running the lint
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"@babel/preset-env": "^7.24.0",
 				"@babel/register": "^7.23.7",
 				"@biomejs/biome": "2.5.7",
-				"@nk-crew/plugin-toolkit": "^0.5.1",
+				"@nk-crew/plugin-toolkit": "^0.6.0",
 				"@playwright/test": "^1.57.0",
 				"@wordpress/e2e-test-utils-playwright": "^1.37.0",
 				"@wordpress/env": "^10.37.0",
@@ -4463,9 +4463,9 @@
 			}
 		},
 		"node_modules/@nk-crew/plugin-toolkit": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.5.1.tgz",
-			"integrity": "sha512-NMNVIZKcwQ6oRu6mSEjpOcme72s6n7f+nzRk9c+rinfjFnr1khB9tZJmLNrjBR1kE1l6FpArXLOWm4nvtZ6Ivg==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.6.0.tgz",
+			"integrity": "sha512-KU9IwgzP8JP9Ra4rlE9UI4OOn8JhHdmyMHhmWDq3DjfuFbIio+STRBlbmxVe/jLEsycESWBoHt1vdR1AH9b5mw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"@babel/preset-env": "^7.24.0",
 		"@babel/register": "^7.23.7",
 		"@biomejs/biome": "2.5.7",
-		"@nk-crew/plugin-toolkit": "^0.5.1",
+		"@nk-crew/plugin-toolkit": "^0.6.0",
 		"@playwright/test": "^1.57.0",
 		"@wordpress/e2e-test-utils-playwright": "^1.37.0",
 		"@wordpress/env": "^10.37.0",

--- a/tests/e2e/specs/added-images-to-block.spec.js
+++ b/tests/e2e/specs/added-images-to-block.spec.js
@@ -60,8 +60,6 @@ test.describe('added images to block', () => {
 		programmatically = false,
 		alternativeSetting = false
 	) {
-		await admin.visitAdminPage('edit.php');
-
 		await admin.createNewPost({
 			title: 'Test Adding Images to a Block Programmatically',
 			postType: 'page',

--- a/tests/e2e/specs/added-images-to-saved-layout.spec.js
+++ b/tests/e2e/specs/added-images-to-saved-layout.spec.js
@@ -67,8 +67,6 @@ test.describe('added images to saved layout', () => {
 		alternativeSetting = false,
 		checkImageSettings = false
 	) {
-		await admin.visitAdminPage('edit.php');
-
 		const images = await getWordpressImages({
 			requestUtils,
 			page,

--- a/tests/e2e/specs/archive.spec.js
+++ b/tests/e2e/specs/archive.spec.js
@@ -27,6 +27,11 @@ import { getPluginSlug } from '../utils/plugin-slug';
 const logsEnabled = process.env.LOGS || false;
 
 test.describe('archive pages', () => {
+	// The permalink structure is a site-wide option that outlives a test, so
+	// tracking what it is already set to turns most `setPermalinkSettings` calls
+	// into no-ops. See the note on the helper itself.
+	let currentPermalinkStructure;
+
 	test.beforeEach(async ({ admin, page, requestUtils }) => {
 		await setPermalinkSettings(admin, page, 'Post name');
 		const pluginName = getPluginSlug();
@@ -862,12 +867,22 @@ test.describe('archive pages', () => {
 			return existingPosts.some((post) => post.title.rendered === title);
 		};
 
-		const images = await getWordpressImages({
-			requestUtils,
-			page,
-			admin,
-			editor,
-		});
+		// Only the `!postExists` branch below consumes these, and `afterEach`
+		// deletes pages and posts but not the portfolio CPT -- so after the
+		// first test every post already exists and fetching or uploading the
+		// images was pure overhead.
+		const missingPosts = (await portfolioPosts).filter(
+			(post) => !postExists(post.title)
+		);
+
+		const images = missingPosts.length
+			? await getWordpressImages({
+					requestUtils,
+					page,
+					admin,
+					editor,
+				})
+			: [];
 
 		// Get the current date and time
 		const currentDate = new Date();
@@ -957,9 +972,23 @@ test.describe('archive pages', () => {
 	 * @param {string} type  - The type of permalink structure to select.
 	 */
 	async function setPermalinkSettings(admin, page, type) {
+		// Two full page loads per call. Every test opened by re-saving the same
+		// `Post name` the `beforeEach` had just written, and the tests that
+		// switch to `Plain` switch back before they finish -- so most of these
+		// calls were writing a value that was already in place.
+		//
+		// The category-feed test also re-saves this screen to flush rewrite
+		// rules, but it drives the permalinks page directly rather than coming
+		// through here, so that flush still happens.
+		if (currentPermalinkStructure === type) {
+			return;
+		}
+
 		await admin.visitAdminPage('options-permalink.php');
 		await page.getByLabel(type).check();
 		await page.getByRole('button', { name: 'Save Changes' }).click();
+
+		currentPermalinkStructure = type;
 	}
 
 	/**

--- a/tests/e2e/specs/click-action-images-saved-layout.spec.js
+++ b/tests/e2e/specs/click-action-images-saved-layout.spec.js
@@ -45,8 +45,6 @@ test.describe('click action gallery images (saved layout)', () => {
 		requestUtils,
 		alternativeSetting = false
 	) {
-		await admin.visitAdminPage('edit.php');
-
 		const images = await getWordpressImages({
 			requestUtils,
 			page,

--- a/tests/e2e/specs/pattern-context.spec.js
+++ b/tests/e2e/specs/pattern-context.spec.js
@@ -93,15 +93,12 @@ test.describe('Pattern Context - Visual Portfolio blocks in patterns', () => {
 			editor,
 		});
 
-		// Create a new page to create the pattern
-		await admin.createNewPost({
-			title: 'Pattern Creation Page',
-			postType: 'page',
-			showWelcomeGuide: false,
-			legacyCanvas: true,
-		});
-
-		// Create a new page to test the pattern
+		// Create a new page to test the pattern.
+		//
+		// A 'Pattern Creation Page' used to be booted immediately before this
+		// one. Nothing ever read from it -- the next `createNewPost` navigated
+		// away and discarded the editor -- so it cost a full editor boot and
+		// left a stray draft behind.
 		await admin.createNewPost({
 			title: 'Test Pattern Context - Group Wrapper',
 			postType: 'page',

--- a/tests/e2e/specs/security-lfi-path-traversal.spec.js
+++ b/tests/e2e/specs/security-lfi-path-traversal.spec.js
@@ -22,43 +22,103 @@ test.describe('security: LFI path traversal', () => {
 		await requestUtils.activatePlugin(pluginName);
 	});
 
-	test.beforeEach(async ({ page }) => {
-		// Navigate to admin to get a valid nonce.
-		await page.goto('/wp-admin/');
+	/**
+	 * Reads the preview nonce, loading wp-admin once for the whole file.
+	 *
+	 * This was a `beforeEach`, so every test paid a full wp-admin page load to
+	 * read one string, while none of them touch the browser otherwise. The
+	 * nonce is `wp_create_nonce( 'vp-ajax-nonce' )`, tied to the admin session
+	 * and stable for far longer than a run.
+	 *
+	 * @param {Object} pg - Playwright page object.
+	 * @return {string} The preview nonce.
+	 */
+	async function getNonce(pg) {
+		if (nonce) {
+			return nonce;
+		}
 
-		// Extract the VP nonce from the admin page.
-		nonce = await page.evaluate(() => {
-			// VPAdminVariables is localized on admin pages when the plugin is active.
+		await pg.goto('/wp-admin/');
+
+		// VPAdminVariables is localized on admin pages when the plugin is active.
+		nonce = await pg.evaluate(() => {
 			if (window.VPAdminVariables && window.VPAdminVariables.nonce) {
 				return window.VPAdminVariables.nonce;
 			}
 			return null;
 		});
-	});
+
+		// Not a reason to skip. Every test used to open with
+		// `test.skip( ! nonce )`, so a missing nonce silently dropped the whole
+		// file and left the run green with no security coverage at all.
+		if (!nonce) {
+			throw new Error(
+				'VPAdminVariables.nonce is not present on /wp-admin/. Without it the preview endpoint is never reached and these tests would assert nothing.'
+			);
+		}
+
+		return nonce;
+	}
+
+	/**
+	 * Posts to the preview endpoint.
+	 *
+	 * @param {Object} pg     - Playwright page object.
+	 * @param {Object} fields - Form fields to send alongside the preview flag.
+	 * @return {Object} Playwright response.
+	 */
+	async function previewRequest(pg, fields) {
+		const previewNonce = await getNonce(pg);
+
+		return pg.request.post(
+			`/?vp_preview=vp_preview&vp_preview_nonce=${previewNonce}`,
+			{
+				form: {
+					vp_preview_frame: 'true',
+					...fields,
+				},
+			}
+		);
+	}
+
+	/**
+	 * Asserts the preview template actually rendered, then returns its body.
+	 *
+	 * Without this the whole file passes against code it never reached.
+	 * `Visual_Portfolio_Preview::is_preview_check()` only sets
+	 * `preview_enabled` when `wp_verify_nonce` succeeds, and `template_redirect`
+	 * returns early otherwise -- so a stale or wrong nonce gets an ordinary
+	 * front page, HTTP 200, with no fatal error and no traversal payload in it.
+	 * Every "should not contain" assertion below is satisfied by that page.
+	 *
+	 * `vp-preview-wrapper` is emitted by `print_template()` on every rendered
+	 * preview and appears nowhere else, so it distinguishes the two.
+	 *
+	 * @param {Object} response - Playwright response.
+	 * @return {string} The response body.
+	 */
+	async function assertPreviewRendered(response) {
+		const body = await response.text();
+
+		expect(body).toContain('vp-preview-wrapper');
+
+		return body;
+	}
 
 	test('preview frame rejects path traversal in vp_items_style', async ({
 		page,
 	}) => {
-		// Skip if nonce not available (plugin not fully loaded on admin page).
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const traversalPayload = '../../../../../../wp-includes';
 
 		// Send the malicious preview request with path traversal in items_style.
-		const response = await page.request.post(
-			`/?vp_preview=vp_preview&vp_preview_nonce=${nonce}`,
-			{
-				form: {
-					vp_preview_frame: 'true',
-					vp_items_style: traversalPayload,
-				},
-			}
-		);
+		const response = await previewRequest(page, {
+			vp_items_style: traversalPayload,
+		});
 
 		// The response should NOT be a 500 error (which indicates LFI triggered a fatal).
 		expect(response.status()).not.toBe(500);
 
-		const body = await response.text();
+		const body = await assertPreviewRendered(response);
 
 		// Should not contain WordPress critical error indicators.
 		expect(body).not.toContain(
@@ -74,23 +134,15 @@ test.describe('security: LFI path traversal', () => {
 	test('preview frame rejects path traversal in vp_filter', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const traversalPayload = '../../../etc';
 
-		const response = await page.request.post(
-			`/?vp_preview=vp_preview&vp_preview_nonce=${nonce}`,
-			{
-				form: {
-					vp_preview_frame: 'true',
-					vp_filter: traversalPayload,
-				},
-			}
-		);
+		const response = await previewRequest(page, {
+			vp_filter: traversalPayload,
+		});
 
 		expect(response.status()).not.toBe(500);
 
-		const body = await response.text();
+		const body = await assertPreviewRendered(response);
 		expect(body).not.toContain(
 			'There has been a critical error on this website'
 		);
@@ -103,23 +155,15 @@ test.describe('security: LFI path traversal', () => {
 	test('preview frame rejects path traversal in vp_sort', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const traversalPayload = '../../../etc';
 
-		const response = await page.request.post(
-			`/?vp_preview=vp_preview&vp_preview_nonce=${nonce}`,
-			{
-				form: {
-					vp_preview_frame: 'true',
-					vp_sort: traversalPayload,
-				},
-			}
-		);
+		const response = await previewRequest(page, {
+			vp_sort: traversalPayload,
+		});
 
 		expect(response.status()).not.toBe(500);
 
-		const body = await response.text();
+		const body = await assertPreviewRendered(response);
 		expect(body).not.toContain(
 			'There has been a critical error on this website'
 		);
@@ -132,23 +176,15 @@ test.describe('security: LFI path traversal', () => {
 	test('preview frame rejects path traversal in vp_pagination_style', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const traversalPayload = '../../../etc';
 
-		const response = await page.request.post(
-			`/?vp_preview=vp_preview&vp_preview_nonce=${nonce}`,
-			{
-				form: {
-					vp_preview_frame: 'true',
-					vp_pagination_style: traversalPayload,
-				},
-			}
-		);
+		const response = await previewRequest(page, {
+			vp_pagination_style: traversalPayload,
+		});
 
 		expect(response.status()).not.toBe(500);
 
-		const body = await response.text();
+		const body = await assertPreviewRendered(response);
 		expect(body).not.toContain(
 			'There has been a critical error on this website'
 		);
@@ -159,23 +195,15 @@ test.describe('security: LFI path traversal', () => {
 	});
 
 	test('preview frame accepts valid items_style values', async ({ page }) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		// 'default' is a built-in items style that should always work.
-		const response = await page.request.post(
-			`/?vp_preview=vp_preview&vp_preview_nonce=${nonce}`,
-			{
-				form: {
-					vp_preview_frame: 'true',
-					vp_items_style: 'default',
-				},
-			}
-		);
+		const response = await previewRequest(page, {
+			vp_items_style: 'default',
+		});
 
 		// Valid value should not cause a 500 error.
 		expect(response.status()).not.toBe(500);
 
-		const body = await response.text();
+		const body = await assertPreviewRendered(response);
 		expect(body).not.toContain(
 			'There has been a critical error on this website'
 		);
@@ -185,25 +213,17 @@ test.describe('security: LFI path traversal', () => {
 	test('preview frame rejects deeply nested path traversal', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const traversalPayload =
 			'../../../../../../../../../../../../etc/passwd';
 
 		// A deeply nested traversal trying to reach system files.
-		const response = await page.request.post(
-			`/?vp_preview=vp_preview&vp_preview_nonce=${nonce}`,
-			{
-				form: {
-					vp_preview_frame: 'true',
-					vp_items_style: traversalPayload,
-				},
-			}
-		);
+		const response = await previewRequest(page, {
+			vp_items_style: traversalPayload,
+		});
 
 		expect(response.status()).not.toBe(500);
 
-		const body = await response.text();
+		const body = await assertPreviewRendered(response);
 		expect(body).not.toContain(
 			'There has been a critical error on this website'
 		);

--- a/tests/e2e/specs/selector-control-values.spec.js
+++ b/tests/e2e/specs/selector-control-values.spec.js
@@ -52,17 +52,44 @@ test.describe('selector control attribute values validation', () => {
 		]);
 	});
 
-	test.beforeEach(async ({ page }) => {
-		// Navigate to admin to get a valid nonce.
-		await page.goto('/wp-admin/');
+	/**
+	 * Reads the preview nonce, loading wp-admin once for the whole file.
+	 *
+	 * This used to be a `beforeEach`, which meant a full wp-admin page load --
+	 * every admin script and stylesheet -- before each of these tests, purely to
+	 * read one string. The nonce stays valid for hours, far longer than a run,
+	 * and nothing here mutates it, so fetching it once is equivalent.
+	 *
+	 * A missing nonce is a failure, not a reason to skip. Each test used to
+	 * carry `test.skip( ! nonce )`, so if `VPAdminVariables` ever stopped being
+	 * printed the whole file would quietly skip and the suite would still be
+	 * green while asserting nothing.
+	 *
+	 * @param {Object} pg - Playwright page object.
+	 * @return {string} The preview nonce.
+	 */
+	async function getNonce(pg) {
+		if (nonce) {
+			return nonce;
+		}
 
-		nonce = await page.evaluate(() => {
+		await pg.goto('/wp-admin/');
+
+		nonce = await pg.evaluate(() => {
 			if (window.VPAdminVariables && window.VPAdminVariables.nonce) {
 				return window.VPAdminVariables.nonce;
 			}
 			return null;
 		});
-	});
+
+		if (!nonce) {
+			throw new Error(
+				'VPAdminVariables.nonce is not present on /wp-admin/. The preview endpoint cannot be exercised without it.'
+			);
+		}
+
+		return nonce;
+	}
 
 	/**
 	 * Helper to make a preview POST request.
@@ -72,8 +99,10 @@ test.describe('selector control attribute values validation', () => {
 	 * @return {Object} Response object.
 	 */
 	async function previewRequest(pg, extraFields = {}) {
+		const previewNonce = await getNonce(pg);
+
 		return pg.request.post(
-			`/?vp_preview=vp_preview&vp_preview_nonce=${nonce}`,
+			`/?vp_preview=vp_preview&vp_preview_nonce=${previewNonce}`,
 			{
 				form: {
 					...BASE_PREVIEW_FORM,
@@ -108,8 +137,6 @@ test.describe('selector control attribute values validation', () => {
 	test('invalid posts_order_by value falls back to default in preview', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_posts_order_by: 'completely_invalid_value',
 		});
@@ -126,8 +153,6 @@ test.describe('selector control attribute values validation', () => {
 	test('invalid items_style value falls back to default in preview', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_items_style: 'nonexistent_skin_style',
 		});
@@ -141,8 +166,6 @@ test.describe('selector control attribute values validation', () => {
 	test('invalid sort value falls back to default in preview', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_sort: 'invalid_sort_option',
 		});
@@ -156,8 +179,6 @@ test.describe('selector control attribute values validation', () => {
 	test('valid selector values render items correctly in preview', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page);
 
 		const body = await assertNoError(response);
@@ -175,8 +196,6 @@ test.describe('selector control attribute values validation', () => {
 	test('show_date with value true renders date in preview', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_items_style_default__show_date: 'true',
 		});
@@ -190,8 +209,6 @@ test.describe('selector control attribute values validation', () => {
 	test('show_date with value false does not render date in preview', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_items_style_default__show_date: 'false',
 		});
@@ -205,8 +222,6 @@ test.describe('selector control attribute values validation', () => {
 	test('show_date with value human renders human format date in preview', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_items_style_default__show_date: 'human',
 		});
@@ -221,8 +236,6 @@ test.describe('selector control attribute values validation', () => {
 	test('show_date with invalid value falls back to default (no date shown)', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_items_style_default__show_date: 'invalid_value',
 		});
@@ -240,8 +253,6 @@ test.describe('selector control attribute values validation', () => {
 	test('show_read_more with value true renders read more button', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_items_style_default__show_read_more: 'true',
 			vp_items_style_default__read_more_label: 'Read More',
@@ -257,8 +268,6 @@ test.describe('selector control attribute values validation', () => {
 	test('show_read_more with invalid value falls back to default (no button)', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		const response = await previewRequest(page, {
 			vp_items_style_default__show_read_more: 'invalid_value',
 		});
@@ -277,8 +286,6 @@ test.describe('selector control attribute values validation', () => {
 	test('dynamic callback selector (post_types_set) accepts arbitrary values', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		// post_types_set has a value_callback, so it should accept arbitrary values
 		// without resetting or causing errors.
 		const response = await previewRequest(page, {
@@ -294,8 +301,6 @@ test.describe('selector control attribute values validation', () => {
 	test('dynamic callback selector does not break with custom post type value', async ({
 		page,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		// Even with a non-standard post type that may not exist,
 		// the dynamic callback selector should not cause a fatal error.
 		const response = await previewRequest(page, {
@@ -314,8 +319,6 @@ test.describe('selector control attribute values validation', () => {
 		admin,
 		editor,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		// Create a page with a VP block using an invalid posts_order_by.
 		await admin.createNewPost({
 			title: 'Test Invalid Selector Value',
@@ -355,8 +358,6 @@ test.describe('selector control attribute values validation', () => {
 		admin,
 		editor,
 	}) => {
-		test.skip(!nonce, 'VP nonce not available on admin page');
-
 		await admin.createNewPost({
 			title: 'Test Show Date True Option',
 			postType: 'page',

--- a/tests/e2e/utils/get-wordpress-images.js
+++ b/tests/e2e/utils/get-wordpress-images.js
@@ -94,9 +94,19 @@ export async function getWordpressImages({
 		return filename.replace(/\.[^/.]+$/, '');
 	}
 
+	// One listing for the whole batch, not one per image. This used to call
+	// `fetchMediaList()` inside the `Promise.all` below, so ten concurrent
+	// requests each pulled the same full `wp/v2/media?per_page=100` response --
+	// and the waste grew with the library, since every response got longer as
+	// tests added attachments.
+	//
+	// Safe to read once: nothing uploads before the lookups finish, and the
+	// fallback uploads below only add slugs that no other entry is searching
+	// for.
+	const existingMedia = alwaysUpload ? [] : await fetchMediaList();
+
 	// Function to check if an image already exists and return its details
-	async function getExistingMediaDetails(filename) {
-		const existingMedia = await fetchMediaList();
+	function getExistingMediaDetails(filename) {
 		return existingMedia.find(
 			(media) => media.slug === removeFileExtension(filename)
 		);
@@ -112,7 +122,7 @@ export async function getWordpressImages({
 				media = await uploadMediaWithRetry(filepath);
 			} else {
 				// Check if the image already exists and retrieve its details.
-				media = await getExistingMediaDetails(object.filename);
+				media = getExistingMediaDetails(object.filename);
 
 				// If the image doesn't exist, upload it.
 				if (!media) {


### PR DESCRIPTION
## The gap

Measured across the plugin family on the same runner, same day:

| suite | tests | time | s/test |
|---|---|---|---|
| **visual-portfolio** | 56 | 9.7m | **10.4** |
| visual-portfolio-pro (this same core suite) | 56 | 12.0m | **12.9** |
| visual-portfolio-pro (Pro suite) | 131 | 10.2m | 4.7 |
| lazy-blocks | 26 | 1.9m | 4.4 |
| ghostkit | 24 | 1.7m | 4.2 |

The Pro suite runs **131 tests in the same wall time this one takes for 56**, in the same job on the same machine. So this isn't the runner and isn't the tests being inherently heavy — it's setup repeated per test.

## What was repeated

| | Before | After |
|---|---|---|
| Full `/wp-admin/` loads just to read a nonce | 20 (one per test in two files) | 2 (one per file) |
| `GET /wp/v2/media?per_page=100` per `getWordpressImages()` call | 10 (one per image, concurrently) | 1 |
| `options-permalink.php` save + reload in `archive` | ~12 | only when the structure actually changes |
| Image fetch/upload in `maybeCreatePortfolioPosts` | every test | only when a post is missing |
| `visitAdminPage('edit.php')` immediately before navigating away | 3 | 0 |
| Editor boots discarded by the next line | 1 | 0 |

Details on each:

- **The nonce.** `selector-control-values.spec.js` and `security-lfi-path-traversal.spec.js` both had a `beforeEach` doing `page.goto('/wp-admin/')` purely to read `window.VPAdminVariables.nonce` — while every test in both files only issues `page.request.post(...)` and never touches the browser. The nonce is `wp_create_nonce('vp-ajax-nonce')`, stable for hours. Now fetched lazily, once per file.
- **The media N+1.** `getExistingMediaDetails` called `fetchMediaList()` *per image*, inside a 10-wide `Promise.all` — ten concurrent requests for the same full media listing, on every one of the ~20 calls per run. Worse over time, since each response grew as tests added attachments. Hoisted above the map.
- **Permalinks.** `setPermalinkSettings` is two page loads, and the permalink structure is a site-wide option that survives between tests. Every test opened by re-saving the same `Post name` its own `beforeEach` had just written. Now a no-op when the structure already matches. The category-feed test's re-save (which exists to flush rewrite rules, not to change the structure) drives the permalinks screen directly and is untouched.
- **Archive images.** `maybeCreatePortfolioPosts` fetched and uploaded all ten images before checking `postExists`. `afterEach` deletes pages and posts but not the portfolio CPT, so from the second test on nothing needed creating and the work was thrown away.
- **Dead navigations.** Three helpers ran `visitAdminPage('edit.php')` and then immediately navigated elsewhere. `get-wordpress-images` only reads `page.url()` when `alternativeSetting` is true, and it is `false` at all three call sites (verified: `added-images-to-saved-layout.spec.js:226,275,387` and `click-action-images-saved-layout.spec.js:212` all use the default).
- **A discarded editor.** `pattern-context.spec.js` booted a 'Pattern Creation Page' and then called `createNewPost` again on the next line, discarding it.

## The security file was passing vacuously

This is the part worth reviewing closely — it's a correctness fix, not a speed one.

All six tests in `security-lfi-path-traversal.spec.js` opened with `test.skip(!nonce, …)`, so if `VPAdminVariables` ever stopped being localised the entire file would skip and CI would stay green with zero security coverage.

The deeper problem is that the skip isn't even needed for the file to pass without testing anything. `Visual_Portfolio_Preview::is_preview_check()` (`classes/class-preview.php:128-142`) only sets `preview_enabled` when `wp_verify_nonce` succeeds, and `template_redirect` (`:176-178`) returns early otherwise. A stale or wrong nonce therefore gets **the ordinary front page, HTTP 200** — which contains no `Fatal error`, no critical-error notice, and no traversal payload. All three assertions in every test pass against a page that never reached the code under test.

Two changes:
- A missing nonce now **throws** instead of skipping.
- Every test asserts the body contains `vp-preview-wrapper`, which `print_template()` emits on every rendered preview and which appears nowhere else. If the preview didn't render, the test fails.

## Dependency

Picks up `@nk-crew/plugin-toolkit@0.6.0` ([nk-crew/plugin-toolkit#2](https://github.com/nk-crew/plugin-toolkit/pull/2)), which stops recording a Playwright trace for tests that pass and restores `reportSlowTests` — the report that would have named this suite the first time it ran.

The lockfile change is deliberately just the four fields for that one package. `npm install --package-lock-only` re-resolved the whole tree and dropped `jquery` and `typescript` (both optional peers) while flipping ~60 entries to `dev: true`, so I reverted that and edited the entry directly instead.

## Verification

Every touched file passes `node --check`. Correctness rests on CI — the `Playwright` job here is the measurement. Worth comparing against the 9.7m / 56-test baseline above.

## Deliberately not included

Flagged during analysis, left alone because each needs a real run or costs coverage:

- Replacing `waitForLoadState('networkidle')` in `archive.spec.js`. Likely the single biggest remaining win (60–150s), but `getArchiveItems` silently `continue`s past items whose image or title doesn't appear in time, and the `networkidle` wait is probably load-bearing insurance for exactly that. Removing it without fixing the silent drops would trade time for confusing intermittent diffs.
- `isVisible({ timeout })` at six call sites in `saved-layout-controls-test.spec.js` — the option is ignored by Playwright (deprecated), so those checks evaluate instantly against whatever the DOM holds at that microsecond. Where the result gates an `if`, the test body is skipped silently.
- Three tests in `saved-layout-controls-test.spec.js` and two in `pattern-context.spec.js` wrap their assertions in `if (…isVisible)`, so they can report success having asserted nothing.
- Shared JSON fixtures are mutated in place in the two image specs and leak between files under `workers: 1`; `click-action-images.spec.js` already clones correctly.
- `added-images-to-saved-layout.spec.js:415-422` does `imageFixtures[imageFixtures.indexOf(x)].id = …` with no guard — `indexOf` returns `-1` on no match and that throws.

The last two are straightforward bugs; I'll send them separately so this PR stays about the timings.