### PR TITLE
fix(e2e): stop image specs sharing a mutated fixture, guard a crash

### DIFF
--- a/tests/e2e/specs/added-images-to-block.spec.js
+++ b/tests/e2e/specs/added-images-to-block.spec.js
@@ -7,7 +7,7 @@ import { expect, test } from '@wordpress/e2e-test-utils-playwright';
 /**
  * Test Images
  */
-import imageFixtures from '../../fixtures/images.json';
+import rawImageFixtures from '../../fixtures/images.json';
 import { getPortfolioPreviewFrame } from '../utils/editor-canvas';
 import { findAsyncSequential } from '../utils/find-async-sequential';
 import { getWordpressImages } from '../utils/get-wordpress-images';
@@ -19,6 +19,14 @@ import {
 import { openPublishedPage } from '../utils/open-published-page';
 import { getPluginSlug } from '../utils/plugin-slug';
 import { waitForPortfolioPreview } from '../utils/portfolio-preview';
+
+// `images.json` is a module singleton: Node caches it, `workers: 1` puts every
+// spec in the same process, and this file writes `.id` and `.alt` back into it.
+// Those writes leaked into the other specs importing the same path -- the two
+// image specs read `.alt` back, and archive.spec.js reads the same objects --
+// so behaviour depended on which file ran first. Work on a copy, the way
+// click-action-images.spec.js already does with `cloneFixture`.
+const imageFixtures = JSON.parse(JSON.stringify(rawImageFixtures));
 
 test.describe('added images to block', () => {
 	test.beforeEach(async ({ requestUtils }) => {

--- a/tests/e2e/specs/added-images-to-saved-layout.spec.js
+++ b/tests/e2e/specs/added-images-to-saved-layout.spec.js
@@ -6,7 +6,7 @@ import { expect, test } from '@wordpress/e2e-test-utils-playwright';
 /**
  * Test Images
  */
-import imageFixtures from '../../fixtures/images.json';
+import rawImageFixtures from '../../fixtures/images.json';
 import {
 	getEditorCanvas,
 	getPortfolioPreviewFrame,
@@ -21,6 +21,14 @@ import {
 import { openPublishedPage } from '../utils/open-published-page';
 import { getPluginSlug } from '../utils/plugin-slug';
 import { waitForPortfolioPreview } from '../utils/portfolio-preview';
+
+// `images.json` is a module singleton: Node caches it, `workers: 1` puts every
+// spec in the same process, and this file writes `.id` and `.alt` back into it.
+// Those writes leaked into the other specs importing the same path -- the two
+// image specs read `.alt` back, and archive.spec.js reads the same objects --
+// so behaviour depended on which file ran first. Work on a copy, the way
+// click-action-images.spec.js already does with `cloneFixture`.
+const imageFixtures = JSON.parse(JSON.stringify(rawImageFixtures));
 
 /**
  * TODO: The test needs to be redone in the future.
@@ -416,6 +424,20 @@ test.describe('added images to saved layout', () => {
 				imageFixtures,
 				async (x) => x.description === itemDescription
 			);
+
+			// `findAsyncSequential` returns undefined when nothing matches, and
+			// `indexOf(undefined)` is -1 -- so the write below threw
+			// "Cannot set properties of undefined", burying whatever the real
+			// failure was. added-images-to-block.spec.js already guards the
+			// identical block; this says which lookup came up empty.
+			expect(
+				foundImage,
+				`no uploaded image has the description "${itemDescription}"`
+			).toBeDefined();
+			expect(
+				foundFixture,
+				`no fixture has the description "${itemDescription}"`
+			).toBeDefined();
 
 			const foundFixtureIndex = imageFixtures.indexOf(foundFixture);
 


### PR DESCRIPTION
Two bugs found while profiling the e2e suite. Neither is about speed, so they're split out of [#288](https://github.com/nk-crew/visual-portfolio/pull/288).

## 1. Three specs share one fixture object, two of them write to it

`tests/fixtures/images.json` is imported by `added-images-to-block.spec.js`, `added-images-to-saved-layout.spec.js` and `archive.spec.js`. Node caches the parsed module, and `workers: 1` puts every spec in the same process — so all three hold **the same objects**.

Both image specs write back into them:

- `added-images-to-block.spec.js` — `imageFixtures[i].id`, `imageFixtures[i].alt`
- `added-images-to-saved-layout.spec.js` — `imageFixtures[i].id`, `imageFixtures[i].alt`

`added-images-to-block` sorts first alphabetically, so its mutations are already in place when `added-images-to-saved-layout` reads `foundFixture.alt` to fill and assert the alt field. The suite's behaviour depends on file order, and a `.only` run or a reordering would change what the later file sees.

`click-action-images.spec.js` already avoids this with a local `cloneFixture` helper. Both image specs now do the same at import.

## 2. Unguarded `indexOf` turns a lookup miss into a crash

`added-images-to-saved-layout.spec.js:415-422`:

```js
const foundFixture = await findAsyncSequential(imageFixtures, ...);
const foundFixtureIndex = imageFixtures.indexOf(foundFixture);
imageFixtures[foundFixtureIndex].id = foundImage.id;
```

`findAsyncSequential` returns `undefined` when nothing matches → `indexOf(undefined)` is `-1` → `imageFixtures[-1].id = …` throws `TypeError: Cannot set properties of undefined`. `foundImage.id` on the same line is unguarded too.

That turns "the image with description X wasn't found" into an unrelated type error several frames away. `added-images-to-block.spec.js:506-516` already wraps the identical block in `if (foundImage)` / `if (foundFixture)`; this adds `expect(...).toBeDefined()` with a message naming the description that came up empty, so a miss reports itself.

## Note

Touches two files that [#288](https://github.com/nk-crew/visual-portfolio/pull/288) also touches, but in different places — they should merge in either order without conflict.