### PR TITLE
perf(gallery): load only the images of the current page

### DIFF
--- a/classes/class-get-portfolio.php
+++ b/classes/class-get-portfolio.php
@@ -1344,6 +1344,116 @@ class Visual_Portfolio_Get {
 	}
 
 	/**
+	 * Fill images with the data stored on their attachment posts.
+	 *
+	 * @param array $images images list.
+	 * @param array $options portfolio options.
+	 *
+	 * @return array
+	 */
+	private static function prepare_images_data( $images, $options ) {
+		if ( empty( $images ) ) {
+			return $images;
+		}
+
+		$images_ids = array();
+		foreach ( $images as $k => $img ) {
+			$images_ids[] = (int) $img['id'];
+		}
+
+		// Find all used attachments.
+		$all_attachments = get_posts(
+			array(
+				'post_type'              => 'attachment',
+				'posts_per_page'         => -1,
+				'paged'                  => -1,
+				'post__in'               => $images_ids,
+				'update_post_term_cache' => false,
+			)
+		);
+
+		// prepare titles and descriptions.
+		foreach ( $images as $k => $img ) {
+			$has_custom_alt     = array_key_exists( 'alt', $img );
+			$item_alt           = $has_custom_alt ? (string) $img['alt'] : '';
+			$title_source       = $options['images_titles_source'] ?? 'custom';
+			$description_source = $options['images_descriptions_source'] ?? 'custom';
+			$img_meta           = array(
+				'title'             => '',
+				'image_title'       => '',
+				'image_description' => '',
+				'image_caption'     => '',
+				'image_alt'         => '',
+				'description'       => '',
+				'caption'           => '',
+				'alt'               => '',
+				'none'              => '',
+				'date'              => '',
+			);
+
+			// Find current attachment post data.
+			$attachment = false;
+			foreach ( $all_attachments as $post ) {
+				if ( $post->ID === (int) $img['id'] ) {
+					$attachment = $post;
+					break;
+				}
+			}
+
+			if ( $attachment ) {
+				// get image meta if needed.
+				if (
+					'none' !== $options['images_titles_source'] ||
+					'none' !== $options['images_descriptions_source'] ||
+
+					'image_title' === $options['images_order_by'] ||
+					'image_caption' === $options['images_order_by'] ||
+					'image_alt' === $options['images_order_by'] ||
+					'image_description' === $options['images_order_by']
+				) {
+					if ( $attachment && 'attachment' === $attachment->post_type ) {
+						$img_meta['title']       = $attachment->post_title;
+						$img_meta['description'] = $attachment->post_content;
+						$img_meta['caption']     = wp_get_attachment_caption( $attachment->ID );
+						$img_meta['alt']         = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
+					}
+				}
+
+				if ( $has_custom_alt && '' !== trim( $item_alt ) ) {
+					$img_meta['alt'] = $item_alt;
+				}
+
+				// title.
+				if ( 'custom' !== $options['images_titles_source'] ) {
+					$images[ $k ]['title'] = $img_meta[ $title_source ] ?? '';
+				}
+
+				// image title.
+				$images[ $k ]['image_title'] = $img_meta['title'] ?? '';
+
+				// description.
+				if ( 'custom' !== $options['images_descriptions_source'] ) {
+					$images[ $k ]['description'] = $img_meta[ $description_source ] ?? '';
+				}
+
+				// image description.
+				$images[ $k ]['image_description'] = $img_meta['description'] ?? '';
+
+				// image caption.
+				$images[ $k ]['image_caption'] = $img_meta['caption'] ?? '';
+
+				// image alt.
+				$images[ $k ]['image_alt'] = $img_meta['alt'] ?? '';
+
+				// add published date.
+				$images[ $k ]['published_time'] = get_the_date( 'Y-m-d H:i:s', $attachment );
+			}
+		}
+
+		return $images;
+	}
+
+	/**
 	 * Get query params array.
 	 *
 	 * @param array $options portfolio options.
@@ -1401,101 +1511,6 @@ class Visual_Portfolio_Get {
 				$images = $options['images'];
 			}
 
-			$images_ids = array();
-			foreach ( $images as $k => $img ) {
-				$images_ids[] = (int) $img['id'];
-			}
-
-			// Find all used attachments.
-			$all_attachments = get_posts(
-				array(
-					'post_type'              => 'attachment',
-					'posts_per_page'         => -1,
-					'paged'                  => -1,
-					'post__in'               => $images_ids,
-					'update_post_meta_cache' => false,
-					'update_post_term_cache' => false,
-				)
-			);
-
-			// prepare titles and descriptions.
-			foreach ( $images as $k => $img ) {
-				$has_custom_alt     = array_key_exists( 'alt', $img );
-				$item_alt           = $has_custom_alt ? (string) $img['alt'] : '';
-				$title_source       = $options['images_titles_source'] ?? 'custom';
-				$description_source = $options['images_descriptions_source'] ?? 'custom';
-				$img_meta           = array(
-					'title'             => '',
-					'image_title'       => '',
-					'image_description' => '',
-					'image_caption'     => '',
-					'image_alt'         => '',
-					'description'       => '',
-					'caption'           => '',
-					'alt'               => '',
-					'none'              => '',
-					'date'              => '',
-				);
-
-				// Find current attachment post data.
-				$attachment = false;
-				foreach ( $all_attachments as $post ) {
-					if ( $post->ID === (int) $img['id'] ) {
-						$attachment = $post;
-						break;
-					}
-				}
-
-				if ( $attachment ) {
-					// get image meta if needed.
-					if (
-						'none' !== $options['images_titles_source'] ||
-						'none' !== $options['images_descriptions_source'] ||
-
-						'image_title' === $options['images_order_by'] ||
-						'image_caption' === $options['images_order_by'] ||
-						'image_alt' === $options['images_order_by'] ||
-						'image_description' === $options['images_order_by']
-					) {
-						if ( $attachment && 'attachment' === $attachment->post_type ) {
-							$img_meta['title']       = $attachment->post_title;
-							$img_meta['description'] = $attachment->post_content;
-							$img_meta['caption']     = wp_get_attachment_caption( $attachment->ID );
-							$img_meta['alt']         = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
-						}
-					}
-
-					if ( $has_custom_alt && '' !== trim( $item_alt ) ) {
-						$img_meta['alt'] = $item_alt;
-					}
-
-					// title.
-					if ( 'custom' !== $options['images_titles_source'] ) {
-						$images[ $k ]['title'] = $img_meta[ $title_source ] ?? '';
-					}
-
-					// image title.
-					$images[ $k ]['image_title'] = $img_meta['title'] ?? '';
-
-					// description.
-					if ( 'custom' !== $options['images_descriptions_source'] ) {
-						$images[ $k ]['description'] = $img_meta[ $description_source ] ?? '';
-					}
-
-					// image description.
-					$images[ $k ]['image_description'] = $img_meta['description'] ?? '';
-
-					// image caption.
-					$images[ $k ]['image_caption'] = $img_meta['caption'] ?? '';
-
-					// image alt.
-					$images[ $k ]['image_alt'] = $img_meta['alt'] ?? '';
-
-					// add published date.
-					$images[ $k ]['published_time'] = get_the_date( 'Y-m-d H:i:s', $attachment );
-				}
-			}
-
 			// order.
 			$custom_order           = false;
 			$custom_order_direction = $options['images_order_direction'];
@@ -1525,6 +1540,17 @@ class Visual_Portfolio_Get {
 						$custom_order_direction = 'desc';
 						break;
 				}
+			}
+
+			// Only these orders read data from the attachment posts. With any other
+			// order the current page is known before the attachments are loaded,
+			// so they are loaded after the slicing below.
+			$order_from_attachments = in_array( $custom_order, array( 'date', 'image_title', 'image_caption', 'image_alt', 'image_description' ), true ) ||
+				( 'title' === $custom_order && 'custom' !== ( $options['images_titles_source'] ?? 'custom' ) ) ||
+				( 'description' === $custom_order && 'custom' !== ( $options['images_descriptions_source'] ?? 'custom' ) );
+
+			if ( $order_from_attachments ) {
+				$images = self::prepare_images_data( $images, $options );
 			}
 
 			if ( $custom_order && ! empty( $images ) ) {
@@ -1597,6 +1623,10 @@ class Visual_Portfolio_Get {
 				if ( $i > $start_from_item && $i <= $end_on_item ) {
 					$query_opts['images'][] = $img;
 				}
+			}
+
+			if ( ! $order_from_attachments ) {
+				$query_opts['images'] = self::prepare_images_data( $query_opts['images'], $options );
 			}
 		} else {
 			$query_opts = array(

--- a/classes/class-get-portfolio.php
+++ b/classes/class-get-portfolio.php
@@ -1356,8 +1356,18 @@ class Visual_Portfolio_Get {
 			return $images;
 		}
 
+		$title_source       = $options['images_titles_source'] ?? 'custom';
+		$description_source = $options['images_descriptions_source'] ?? 'custom';
+		$order_by           = $options['images_order_by'] ?? 'default';
+
+		// Attachment meta is read below only for these sources and orders,
+		// so the rest of the galleries don't pay for the meta cache.
+		$with_meta = 'none' !== $title_source ||
+			'none' !== $description_source ||
+			in_array( $order_by, array( 'image_title', 'image_caption', 'image_alt', 'image_description' ), true );
+
 		$images_ids = array();
-		foreach ( $images as $k => $img ) {
+		foreach ( $images as $img ) {
 			$images_ids[] = (int) $img['id'];
 		}
 
@@ -1368,86 +1378,68 @@ class Visual_Portfolio_Get {
 				'posts_per_page'         => -1,
 				'paged'                  => -1,
 				'post__in'               => $images_ids,
+				'update_post_meta_cache' => $with_meta,
 				'update_post_term_cache' => false,
 			)
 		);
 
+		$all_attachments = array_column( $all_attachments, null, 'ID' );
+
 		// prepare titles and descriptions.
 		foreach ( $images as $k => $img ) {
-			$has_custom_alt     = array_key_exists( 'alt', $img );
-			$item_alt           = $has_custom_alt ? (string) $img['alt'] : '';
-			$title_source       = $options['images_titles_source'] ?? 'custom';
-			$description_source = $options['images_descriptions_source'] ?? 'custom';
-			$img_meta           = array(
-				'title'             => '',
-				'image_title'       => '',
-				'image_description' => '',
-				'image_caption'     => '',
-				'image_alt'         => '',
-				'description'       => '',
-				'caption'           => '',
-				'alt'               => '',
-				'none'              => '',
-				'date'              => '',
+			$attachment = $all_attachments[ (int) $img['id'] ] ?? false;
+
+			// Nothing to take the data from once the attachment is deleted.
+			if ( ! $attachment ) {
+				continue;
+			}
+
+			$has_custom_alt = array_key_exists( 'alt', $img );
+			$item_alt       = $has_custom_alt ? (string) $img['alt'] : '';
+			$img_meta       = array(
+				'title'       => '',
+				'description' => '',
+				'caption'     => '',
+				'alt'         => '',
+				'none'        => '',
 			);
 
-			// Find current attachment post data.
-			$attachment = false;
-			foreach ( $all_attachments as $post ) {
-				if ( $post->ID === (int) $img['id'] ) {
-					$attachment = $post;
-					break;
-				}
+			// get image meta if needed.
+			if ( $with_meta ) {
+				$img_meta['title']       = $attachment->post_title;
+				$img_meta['description'] = $attachment->post_content;
+				$img_meta['caption']     = wp_get_attachment_caption( $attachment->ID );
+				$img_meta['alt']         = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
 			}
 
-			if ( $attachment ) {
-				// get image meta if needed.
-				if (
-					'none' !== $options['images_titles_source'] ||
-					'none' !== $options['images_descriptions_source'] ||
-
-					'image_title' === $options['images_order_by'] ||
-					'image_caption' === $options['images_order_by'] ||
-					'image_alt' === $options['images_order_by'] ||
-					'image_description' === $options['images_order_by']
-				) {
-					if ( $attachment && 'attachment' === $attachment->post_type ) {
-						$img_meta['title']       = $attachment->post_title;
-						$img_meta['description'] = $attachment->post_content;
-						$img_meta['caption']     = wp_get_attachment_caption( $attachment->ID );
-						$img_meta['alt']         = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
-					}
-				}
-
-				if ( $has_custom_alt && '' !== trim( $item_alt ) ) {
-					$img_meta['alt'] = $item_alt;
-				}
-
-				// title.
-				if ( 'custom' !== $options['images_titles_source'] ) {
-					$images[ $k ]['title'] = $img_meta[ $title_source ] ?? '';
-				}
-
-				// image title.
-				$images[ $k ]['image_title'] = $img_meta['title'] ?? '';
-
-				// description.
-				if ( 'custom' !== $options['images_descriptions_source'] ) {
-					$images[ $k ]['description'] = $img_meta[ $description_source ] ?? '';
-				}
-
-				// image description.
-				$images[ $k ]['image_description'] = $img_meta['description'] ?? '';
-
-				// image caption.
-				$images[ $k ]['image_caption'] = $img_meta['caption'] ?? '';
-
-				// image alt.
-				$images[ $k ]['image_alt'] = $img_meta['alt'] ?? '';
-
-				// add published date.
-				$images[ $k ]['published_time'] = get_the_date( 'Y-m-d H:i:s', $attachment );
+			if ( $has_custom_alt && '' !== trim( $item_alt ) ) {
+				$img_meta['alt'] = $item_alt;
 			}
+
+			// title.
+			if ( 'custom' !== $title_source ) {
+				$images[ $k ]['title'] = $img_meta[ $title_source ] ?? '';
+			}
+
+			// image title.
+			$images[ $k ]['image_title'] = $img_meta['title'];
+
+			// description.
+			if ( 'custom' !== $description_source ) {
+				$images[ $k ]['description'] = $img_meta[ $description_source ] ?? '';
+			}
+
+			// image description.
+			$images[ $k ]['image_description'] = $img_meta['description'];
+
+			// image caption.
+			$images[ $k ]['image_caption'] = $img_meta['caption'];
+
+			// image alt.
+			$images[ $k ]['image_alt'] = $img_meta['alt'];
+
+			// add published date.
+			$images[ $k ]['published_time'] = get_the_date( 'Y-m-d H:i:s', $attachment );
 		}
 
 		return $images;
@@ -1542,12 +1534,14 @@ class Visual_Portfolio_Get {
 				}
 			}
 
-			// Only these orders read data from the attachment posts. With any other
-			// order the current page is known before the attachments are loaded,
-			// so they are loaded after the slicing below.
-			$order_from_attachments = in_array( $custom_order, array( 'date', 'image_title', 'image_caption', 'image_alt', 'image_description' ), true ) ||
-				( 'title' === $custom_order && 'custom' !== ( $options['images_titles_source'] ?? 'custom' ) ) ||
-				( 'description' === $custom_order && 'custom' !== ( $options['images_descriptions_source'] ?? 'custom' ) );
+			// Sorting reads the image data from the attachment posts, so the whole
+			// gallery has to be loaded before the page can be picked. Manual and
+			// random orders, and the ones sorting by the values stored in the block,
+			// are known upfront — those load the current page only, after the slicing.
+			$order_from_attachments = $custom_order &&
+				! in_array( $custom_order, array( 'default', 'rand' ), true ) &&
+				! ( 'title' === $custom_order && 'custom' === ( $options['images_titles_source'] ?? 'custom' ) ) &&
+				! ( 'description' === $custom_order && 'custom' === ( $options['images_descriptions_source'] ?? 'custom' ) );
 
 			if ( $order_from_attachments ) {
 				$images = self::prepare_images_data( $images, $options );
@@ -1625,7 +1619,10 @@ class Visual_Portfolio_Get {
 				}
 			}
 
-			if ( ! $order_from_attachments ) {
+			// The filter list is built from the categories stored in the block, so
+			// it never reads the attachment data — and `$for_filter` keeps every
+			// image in the slice, which would load the whole gallery for nothing.
+			if ( ! $order_from_attachments && ! $for_filter ) {
 				$query_opts['images'] = self::prepare_images_data( $query_opts['images'], $options );
 			}
 		} else {

--- a/tests/phpunit/unit/test-class-get-portfolio-image-alt.php
+++ b/tests/phpunit/unit/test-class-get-portfolio-image-alt.php
@@ -35,8 +35,9 @@ class Test_Class_Get_Portfolio_Image_Alt extends WP_UnitTestCase {
 				'images_order_by'            => 'default',
 				'images_order_direction'     => 'asc',
 				'items_count'                => 10,
+				'pagination'                 => 'paged',
 			),
-			true
+			false
 		);
 
 		$this->assertNotEmpty( $query['images'] );
@@ -69,8 +70,9 @@ class Test_Class_Get_Portfolio_Image_Alt extends WP_UnitTestCase {
 				'images_order_by'            => 'default',
 				'images_order_direction'     => 'asc',
 				'items_count'                => 10,
+				'pagination'                 => 'paged',
 			),
-			true
+			false
 		);
 
 		$this->assertNotEmpty( $query['images'] );
@@ -103,8 +105,9 @@ class Test_Class_Get_Portfolio_Image_Alt extends WP_UnitTestCase {
 				'images_order_by'            => 'default',
 				'images_order_direction'     => 'asc',
 				'items_count'                => 10,
+				'pagination'                 => 'paged',
 			),
-			true
+			false
 		);
 
 		$this->assertNotEmpty( $query['images'] );

--- a/tests/phpunit/unit/test-class-get-portfolio-images-query.php
+++ b/tests/phpunit/unit/test-class-get-portfolio-images-query.php
@@ -40,6 +40,8 @@ class Test_Class_Get_Portfolio_Images_Query extends WP_UnitTestCase {
 					// 7 and 12 are coprime, so every title is unique and the
 					// title order differs from the gallery order.
 					'post_title'     => sprintf( 'Title %02d', ( $i * 7 ) % 12 ),
+					// Same trick for the upload date: unique, and in a third order.
+					'post_date'      => sprintf( '2024-%02d-01 10:00:00', 1 + ( ( $i * 5 ) % 12 ) ),
 					'post_mime_type' => 'image/jpeg',
 				)
 			);
@@ -58,7 +60,7 @@ class Test_Class_Get_Portfolio_Images_Query extends WP_UnitTestCase {
 	public function tear_down() {
 		remove_action( 'pre_get_posts', array( $this, 'capture_attachment_query' ) );
 
-		unset( $_GET['vp_page'] );
+		unset( $_GET['vp_page'], $_GET['vp_sort'] );
 
 		parent::tear_down();
 	}
@@ -78,10 +80,11 @@ class Test_Class_Get_Portfolio_Images_Query extends WP_UnitTestCase {
 	 * Get query params for the gallery.
 	 *
 	 * @param array $options options to override.
+	 * @param bool  $for_filter get the params for the filter list.
 	 *
 	 * @return array
 	 */
-	private function get_query_params( $options = array() ) {
+	private function get_query_params( $options = array(), $for_filter = false ) {
 		$images = array();
 		foreach ( $this->attachment_ids as $id ) {
 			$images[] = array(
@@ -103,8 +106,25 @@ class Test_Class_Get_Portfolio_Images_Query extends WP_UnitTestCase {
 					'pagination'                 => 'paged',
 				),
 				$options
-			)
+			),
+			$for_filter
 		);
+	}
+
+	/**
+	 * Gallery attachments sorted by their upload date.
+	 *
+	 * @return array
+	 */
+	private function ids_by_date() {
+		$by_date = array();
+		foreach ( $this->attachment_ids as $id ) {
+			$by_date[ get_post_field( 'post_date', $id ) ] = $id;
+		}
+
+		ksort( $by_date );
+
+		return array_values( $by_date );
 	}
 
 	/**
@@ -157,5 +177,58 @@ class Test_Class_Get_Portfolio_Images_Query extends WP_UnitTestCase {
 			$this->assertSame( get_post_meta( $image['id'], '_wp_attachment_image_alt', true ), $image['image_alt'] );
 			$this->assertNotEmpty( $image['published_time'] );
 		}
+	}
+
+	/**
+	 * Images of the current page still take their title from the attachment.
+	 */
+	public function test_current_page_images_take_the_title_from_the_attachment() {
+		$_GET['vp_page'] = 2;
+
+		$query = $this->get_query_params( array( 'images_titles_source' => 'title' ) );
+
+		$this->assertCount( 1, $this->requested_ids );
+		$this->assertCount( 4, $this->requested_ids[0] );
+
+		foreach ( $query['images'] as $image ) {
+			$this->assertSame( get_post_field( 'post_title', $image['id'] ), $image['title'] );
+		}
+	}
+
+	/**
+	 * Sorting by the upload date needs every attachment too.
+	 */
+	public function test_order_by_date_loads_every_attachment() {
+		$_GET['vp_page'] = 2;
+
+		$query = $this->get_query_params( array( 'images_order_by' => 'date' ) );
+
+		$this->assertCount( 1, $this->requested_ids );
+		$this->assertSame( $this->attachment_ids, $this->requested_ids[0] );
+		$this->assertSame( array_slice( $this->ids_by_date(), 4, 4 ), wp_list_pluck( $query['images'], 'id' ) );
+	}
+
+	/**
+	 * The sort request overrides the stored order, so the load follows the request.
+	 */
+	public function test_sort_request_overrides_the_stored_order() {
+		$_GET['vp_page'] = 2;
+		$_GET['vp_sort'] = 'date';
+
+		$query = $this->get_query_params();
+
+		$this->assertCount( 1, $this->requested_ids );
+		$this->assertSame( $this->attachment_ids, $this->requested_ids[0] );
+		$this->assertSame( array_slice( $this->ids_by_date(), 4, 4 ), wp_list_pluck( $query['images'], 'id' ) );
+	}
+
+	/**
+	 * The filter list is built from the block data, so it loads no attachment.
+	 */
+	public function test_filter_list_loads_no_attachments() {
+		$query = $this->get_query_params( array(), true );
+
+		$this->assertCount( 12, $query['images'] );
+		$this->assertSame( array(), $this->requested_ids );
 	}
 }

--- a/tests/phpunit/unit/test-class-get-portfolio-images-query.php
+++ b/tests/phpunit/unit/test-class-get-portfolio-images-query.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests which attachments the Images content source loads.
+ *
+ * @package Visual Portfolio
+ */
+
+/**
+ * Test case for attachment loading in Visual_Portfolio_Get::get_query_params().
+ */
+class Test_Class_Get_Portfolio_Images_Query extends WP_UnitTestCase {
+	/**
+	 * Gallery attachments, in the order they are added to the gallery.
+	 *
+	 * @var array
+	 */
+	private $attachment_ids = array();
+
+	/**
+	 * `post__in` of every attachment query made during a test.
+	 *
+	 * @var array
+	 */
+	private $requested_ids = array();
+
+	/**
+	 * Create a gallery of 12 attachments with unique titles.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->attachment_ids = array();
+		$this->requested_ids  = array();
+
+		for ( $i = 1; $i <= 12; $i++ ) {
+			$id = wp_insert_post(
+				array(
+					'post_type'      => 'attachment',
+					'post_status'    => 'inherit',
+					// 7 and 12 are coprime, so every title is unique and the
+					// title order differs from the gallery order.
+					'post_title'     => sprintf( 'Title %02d', ( $i * 7 ) % 12 ),
+					'post_mime_type' => 'image/jpeg',
+				)
+			);
+
+			update_post_meta( $id, '_wp_attachment_image_alt', sprintf( 'Alt %02d', $i ) );
+
+			$this->attachment_ids[] = $id;
+		}
+
+		add_action( 'pre_get_posts', array( $this, 'capture_attachment_query' ) );
+	}
+
+	/**
+	 * Reset the request and the captured queries.
+	 */
+	public function tear_down() {
+		remove_action( 'pre_get_posts', array( $this, 'capture_attachment_query' ) );
+
+		unset( $_GET['vp_page'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Remember the attachments each query asked for.
+	 *
+	 * @param WP_Query $query current query.
+	 */
+	public function capture_attachment_query( $query ) {
+		if ( 'attachment' === $query->get( 'post_type' ) ) {
+			$this->requested_ids[] = array_map( 'intval', (array) $query->get( 'post__in' ) );
+		}
+	}
+
+	/**
+	 * Get query params for the gallery.
+	 *
+	 * @param array $options options to override.
+	 *
+	 * @return array
+	 */
+	private function get_query_params( $options = array() ) {
+		$images = array();
+		foreach ( $this->attachment_ids as $id ) {
+			$images[] = array(
+				'id'     => $id,
+				'imgUrl' => 'https://example.com/image.jpg',
+			);
+		}
+
+		return Visual_Portfolio_Get::get_query_params(
+			array_merge(
+				array(
+					'content_source'             => 'images',
+					'images'                     => $images,
+					'images_titles_source'       => 'custom',
+					'images_descriptions_source' => 'custom',
+					'images_order_by'            => 'default',
+					'images_order_direction'     => 'asc',
+					'items_count'                => 4,
+					'pagination'                 => 'paged',
+				),
+				$options
+			)
+		);
+	}
+
+	/**
+	 * Manual order is known upfront, so only the current page is loaded.
+	 */
+	public function test_manual_order_loads_only_the_current_page_attachments() {
+		$_GET['vp_page'] = 2;
+
+		$query = $this->get_query_params();
+
+		$this->assertCount( 4, $query['images'] );
+		$this->assertCount( 1, $this->requested_ids );
+		$this->assertSame( array_slice( $this->attachment_ids, 4, 4 ), $this->requested_ids[0] );
+	}
+
+	/**
+	 * Sorting by attachment data needs every attachment of the gallery.
+	 */
+	public function test_order_by_image_title_loads_every_attachment() {
+		$_GET['vp_page'] = 2;
+
+		$query = $this->get_query_params( array( 'images_order_by' => 'image_title' ) );
+
+		$this->assertCount( 1, $this->requested_ids );
+		$this->assertSame( $this->attachment_ids, $this->requested_ids[0] );
+
+		// The page is a slice of the whole gallery sorted by attachment title.
+		$sorted = array();
+		foreach ( $this->attachment_ids as $id ) {
+			$sorted[ get_post_field( 'post_title', $id ) ] = $id;
+		}
+		ksort( $sorted );
+
+		$this->assertSame(
+			array_slice( array_values( $sorted ), 4, 4 ),
+			wp_list_pluck( $query['images'], 'id' )
+		);
+	}
+
+	/**
+	 * Images of the current page keep the data stored on their attachments.
+	 */
+	public function test_current_page_images_keep_attachment_data() {
+		$_GET['vp_page'] = 2;
+
+		$query = $this->get_query_params();
+
+		foreach ( $query['images'] as $image ) {
+			$this->assertSame( get_post_field( 'post_title', $image['id'] ), $image['image_title'] );
+			$this->assertSame( get_post_meta( $image['id'], '_wp_attachment_image_alt', true ), $image['image_alt'] );
+			$this->assertNotEmpty( $image['published_time'] );
+		}
+	}
+}


### PR DESCRIPTION
The Images content source loaded every attachment of a gallery and then threw away all but the current page. That query also disabled the meta cache, so the `_wp_attachment_image_alt` lookup right below it added one more query per image — a 190 image gallery cost 191 queries to render 24 items.

The order is now resolved before the attachments are loaded. Only sorting by data that lives on the attachment posts needs the whole gallery; every other order is known upfront, so the attachments are loaded after the page is sliced. The filter list is skipped entirely — it is built from the categories stored in the block and never touched the attachment data — and the meta cache is primed only when the image meta is actually read.

Measured on a 190 image gallery showing 24 items, cold caches:

| Call | Before | After |
| --- | --- | --- |
| Render, manual order (the default) | 191 queries, 190 attachments | 2 queries, 24 attachments |
| Render, order by date or image title | 191 queries, 190 attachments | 2 queries, 190 attachments |
| Render, both text sources set to None | 191 queries, all postmeta | 1 query, no postmeta |
| Filter list | 191 queries, 190 attachments | none |

This came out of a support report: a page ran the gallery query five times, once for the post's own gallery and once for each of four related posts. The theme builds its related-posts teasers by rendering the whole post content and stripping the tags, so every related gallery renders and is thrown away. That part is the theme's, but the price of one render is ours.

**Behaviour is unchanged where it is visible.** `get_query_params()` was compared against master across 3240 combinations — every order, title source, description source, direction, `?vp_sort` value, page, and both the render and the filter call. The render results are byte identical, and the resulting image order is identical in all 3240. What changed is that the filter call no longer fills `image_title`, `image_alt`, `published_time` and friends on its images: nothing reads them (`get_images_terms()` uses `categories`, `get_filter_active_item()` uses the request), which is why the three alt tests that inspected them moved to the render path, where that data is prepared now. The rendered markup of a gallery with a filter, two pages and three sort orders is byte identical to master across eight URL variants.

Sorting by attachment data still loads the whole gallery, because it has to know every title before it can pick a page.
