### PR TITLE
chore(release): prepare 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ All notable changes to this project will be documented in this file.
 * raised the minimum PHP requirement to 7.4
 * **Pro:**
 * added Gallery Loop support to every Pro source, so social streams, protected galleries and Pro layouts work inside the new blocks
-* added WordPress 7.1 compatibility
 * fixed YouTube video backgrounds asking some visitors to sign in before playing
 * raised the minimum PHP requirement to 7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+= 3.8.0 - Aug 26, 2026 =
+
+* added Gallery Item blocks for building the item template inside the experimental Gallery Loop: Image, Title, Description, Date, Author, Categories, Read More, Cover and Meta
+* added WordPress 7.1 compatibility
+* improved gallery loading speed on portfolios with many images
+* fixed Load More fetching the next page and adding nothing, on sites whose markup contains `<body` inside inline CSS or JavaScript
+* fixed the block editor preview jumping while it resized
+* fixed the Elementor widget preview rendering without its styles
+* raised the minimum PHP requirement to 7.4
+* **Pro:**
+* added Gallery Loop support to every Pro source, so social streams, protected galleries and Pro layouts work inside the new blocks
+* added WordPress 7.1 compatibility
+* fixed YouTube video backgrounds asking some visitors to sign in before playing
+* raised the minimum PHP requirement to 7.4
+
 = 3.7.1 - Jul 21, 2026 =
 
 * fixed Fancybox afterShow callback arguments so popup listeners receive the gallery instance correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 * **Pro:**
 * added Gallery Loop support to every Pro source, so social streams, protected galleries and Pro layouts work inside the new blocks
 * fixed YouTube video backgrounds asking some visitors to sign in before playing
-* raised the minimum PHP requirement to 7.4
 
 = 3.7.1 - Jul 21, 2026 =
 

--- a/class-visual-portfolio.php
+++ b/class-visual-portfolio.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:  Visual Portfolio
  * Description:  Gallery and portfolio plugin with gallery blocks and layouts for the editor.
- * Version:      3.7.1
+ * Version:      3.8.0
  * Plugin URI:   https://www.visualportfolio.com/?utm_source=wordpress.org&utm_medium=readme&utm_campaign=byline
  * Author:       Visual Portfolio Team
  * Author URI:   https://www.visualportfolio.com/?utm_source=wordpress.org&utm_medium=readme&utm_campaign=byline
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'VISUAL_PORTFOLIO_VERSION' ) ) {
-	define( 'VISUAL_PORTFOLIO_VERSION', '3.7.1' );
+	define( 'VISUAL_PORTFOLIO_VERSION', '3.8.0' );
 }
 
 if ( ! class_exists( 'Visual_Portfolio' ) ) :

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "visual-portfolio",
 	"title": "Visual Portfolio",
-	"version": "3.7.1",
+	"version": "3.8.0",
 	"description": "Portfolio post type with visual editor",
 	"license": "GPL-2.0",
 	"author": "Visual Portfolio Team <https://www.visualportfolio.com>",

--- a/readme.txt
+++ b/readme.txt
@@ -347,7 +347,6 @@ For more information, feel free to visit [Visual Portfolio official website](htt
 * raised the minimum PHP requirement to 7.4
 * **Pro:**
 * added Gallery Loop support to every Pro source, so social streams, protected galleries and Pro layouts work inside the new blocks
-* added WordPress 7.1 compatibility
 * fixed YouTube video backgrounds asking some visitors to sign in before playing
 * raised the minimum PHP requirement to 7.4
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@
 * Requires at least: 6.2
 * Tested up to: 7.1
 * Requires PHP: 7.4
-* Stable tag: 3.7.1
+* Stable tag: 3.8.0
 * License: GPLv2 or later
 * License URI: <http://www.gnu.org/licenses/gpl-2.0.html>
 
@@ -335,6 +335,21 @@ Yes, Visual Portfolio has full translation and localization support via the `vis
 For more information, feel free to visit [Visual Portfolio official website](https://www.visualportfolio.com/?utm_source=wordpress.org&utm_medium=faq&utm_campaign=docs).
 
 ## Changelog ##
+
+= 3.8.0 - Aug 26, 2026 =
+
+* added Gallery Item blocks for building the item template inside the experimental Gallery Loop: Image, Title, Description, Date, Author, Categories, Read More, Cover and Meta
+* added WordPress 7.1 compatibility
+* improved gallery loading speed on portfolios with many images
+* fixed Load More fetching the next page and adding nothing, on sites whose markup contains `<body` inside inline CSS or JavaScript
+* fixed the block editor preview jumping while it resized
+* fixed the Elementor widget preview rendering without its styles
+* raised the minimum PHP requirement to 7.4
+* **Pro:**
+* added Gallery Loop support to every Pro source, so social streams, protected galleries and Pro layouts work inside the new blocks
+* added WordPress 7.1 compatibility
+* fixed YouTube video backgrounds asking some visitors to sign in before playing
+* raised the minimum PHP requirement to 7.4
 
 = 3.7.1 - Jul 21, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -348,7 +348,6 @@ For more information, feel free to visit [Visual Portfolio official website](htt
 * **Pro:**
 * added Gallery Loop support to every Pro source, so social streams, protected galleries and Pro layouts work inside the new blocks
 * fixed YouTube video backgrounds asking some visitors to sign in before playing
-* raised the minimum PHP requirement to 7.4
 
 = 3.7.1 - Jul 21, 2026 =
 


### PR DESCRIPTION
Minor rather than patch, because the range adds capability rather than only fixing things: the Gallery Item blocks (Image, Title, Description, Date, Author, Categories, Read More, Cover, Meta) turn the experimental Gallery Loop from a single block into a family with a real server-side items pipeline. Everything else in the twenty commits since `v3.7.1` is WordPress 7.1 work, fixes and tooling.

The entry goes in both `readme.txt` and `CHANGELOG.md`, and its `**Pro:**` section covers the fifteen unreleased commits in `visual-portfolio-pro`, which has no changelog of its own.

Nothing is released here. No tag, no deploy.

## Calls worth checking

The wording is the thing to review, so it is worth knowing what I decided not to write down.

| Commit | Decision |
| --- | --- |
| `feat(modules): bring the Pro half of the Gallery Loop blocks` | Its body describes a protected gallery rendering to everyone. Folded into the feature line, not written up as a security fix: at `v3.7.1` the loop block had no PHP render callback at all, so the pipeline that could leak was introduced and fixed inside this same range and no released version had it. |
| `fix(preview): match the editor's isolation policy in the legacy preview` | Folded into the WordPress 7.1 line rather than given its own, since both describe the editor preview under 7.1. |
| `fix(php): add the missing ABSPATH guards` | Dropped. Hardening with no symptom a user could have hit. |
| `fix(loop): harden the experimental gallery loop blocks` | Folded into the feature line, same range as the feature. |
| `chore(deps)`, `ci:`, `chore(e2e)`, `fix(i18n)`, `chore(dev)`, `chore(git)`, `chore(lint)`, `perf(e2e)`, `fix(e2e)` (12 commits) | Dropped. Nothing a user reaches. |

`raised the minimum PHP requirement to 7.4` appears in both sections because the free plugin and the Pro plugin each moved their own header.