### PR TITLE
fix(plugin): load nothing next to Pro instead of deactivating

### DIFF
--- a/class-visual-portfolio.php
+++ b/class-visual-portfolio.php
@@ -42,8 +42,38 @@ if (
 	in_array( plugin_basename( __FILE__ ), $vpf_active_plugins, true ) &&
 	in_array( 'visual-portfolio-pro/class-visual-portfolio-pro.php', $vpf_active_plugins, true )
 ) {
-	unset( $vpf_active_plugins );
-	return;
+	$vpf_pro_file = WP_PLUGIN_DIR . '/visual-portfolio-pro/class-visual-portfolio-pro.php';
+
+	// `active_plugins` goes on naming a plugin whose directory was removed by hand
+	// and WordPress simply skips it, so stepping aside for one of those would leave
+	// the site with neither plugin.
+	$vpf_step_aside = file_exists( $vpf_pro_file );
+
+	/*
+	 * Pro up to 3.8.0 reads an undefined `VISUAL_PORTFOLIO_VERSION` as a sign that
+	 * an unsupported core is installed, and deactivates this plugin from its own
+	 * bootstrap. On a network that takes it off every site, including the ones with
+	 * no Pro at all, so this copy loads in front of such a Pro and leaves the class
+	 * guard below to keep it inert. Once `VISUAL_PORTFOLIO_PRO` is defined that
+	 * decision is already behind us for this request, and the version is moot.
+	 */
+	if ( $vpf_step_aside && ! defined( 'VISUAL_PORTFOLIO_PRO' ) ) {
+		$vpf_pro_data = get_file_data( $vpf_pro_file, array( 'Version' => 'Version' ) );
+
+		$vpf_step_aside = ! empty( $vpf_pro_data['Version'] ) &&
+			version_compare( $vpf_pro_data['Version'], '3.8.1-alpha', '>=' );
+
+		unset( $vpf_pro_data );
+	}
+
+	unset( $vpf_pro_file );
+
+	if ( $vpf_step_aside ) {
+		unset( $vpf_active_plugins, $vpf_step_aside );
+		return;
+	}
+
+	unset( $vpf_step_aside );
 }
 
 unset( $vpf_active_plugins );

--- a/class-visual-portfolio.php
+++ b/class-visual-portfolio.php
@@ -17,6 +17,37 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/*
+ * Visual Portfolio Pro carries its own copy of this core, so only one of the two
+ * may run. Which copy PHP reaches first depends on the order WordPress includes
+ * plugins in, and that order is not ours to pick: network-activated plugins come
+ * before site-activated ones, and a third party can reorder `active_plugins`. So
+ * the standalone plugin steps aside on its own whenever the Pro plugin is active,
+ * before it defines anything at all.
+ *
+ * Only the activated plugin steps aside. The copy inside the Pro plugin, and any
+ * copy embedded in a theme or another plugin, is not in the list below and keeps
+ * loading as before.
+ */
+$vpf_active_plugins = (array) get_option( 'active_plugins', array() );
+
+if ( is_multisite() ) {
+	$vpf_active_plugins = array_merge(
+		$vpf_active_plugins,
+		array_keys( (array) get_site_option( 'active_sitewide_plugins', array() ) )
+	);
+}
+
+if (
+	in_array( plugin_basename( __FILE__ ), $vpf_active_plugins, true ) &&
+	in_array( 'visual-portfolio-pro/class-visual-portfolio-pro.php', $vpf_active_plugins, true )
+) {
+	unset( $vpf_active_plugins );
+	return;
+}
+
+unset( $vpf_active_plugins );
+
 if ( ! defined( 'VISUAL_PORTFOLIO_VERSION' ) ) {
 	define( 'VISUAL_PORTFOLIO_VERSION', '3.8.0' );
 }

--- a/class-visual-portfolio.php
+++ b/class-visual-portfolio.php
@@ -200,19 +200,35 @@ if ( ! class_exists( 'Visual_Portfolio' ) ) :
 			$this->plugin_path     = plugin_dir_path( __FILE__ );
 			$this->plugin_url      = plugin_dir_url( __FILE__ );
 
-			// Check for new standalone Pro plugin and for old Pro addon plugin for back compatibility.
-			if ( $this->is_pro() ) {
-				$this->pro_plugin_path = plugin_dir_path( WP_PLUGIN_DIR . '/visual-portfolio-pro/class-visual-portfolio-pro.php' );
-				$this->pro_plugin_url  = plugin_dir_url( WP_PLUGIN_DIR . '/visual-portfolio-pro/class-visual-portfolio-pro.php' );
-			}
+			$this->set_pro_plugin_paths();
 
 			// include helper files.
 			$this->include_dependencies();
 
 			// Hooks.
+			add_action( 'plugins_loaded', array( $this, 'set_pro_plugin_paths' ) );
 			add_action( 'init', array( $this, 'earlier_init_hook' ), 5 );
 			add_action( 'init', array( $this, 'init_hook' ) );
 			add_action( 'init', array( $this, 'run_deferred_rewrite_rules' ), 20 );
+		}
+
+		/**
+		 * Point at the Pro plugin directory, for the new standalone Pro plugin and for the
+		 * old Pro addon plugin alike.
+		 *
+		 * `register_activation_hook()` builds this instance while the main file is being
+		 * included, so `init()` can run before the Pro plugin's own file has, and `is_pro()`
+		 * would answer no. Asking again once every plugin is in keeps the Pro template and
+		 * style lookups in `Visual_Portfolio_Templates` working whichever of the two loaded
+		 * first.
+		 */
+		public function set_pro_plugin_paths() {
+			if ( ! $this->is_pro() ) {
+				return;
+			}
+
+			$this->pro_plugin_path = plugin_dir_path( WP_PLUGIN_DIR . '/visual-portfolio-pro/class-visual-portfolio-pro.php' );
+			$this->pro_plugin_url  = plugin_dir_url( WP_PLUGIN_DIR . '/visual-portfolio-pro/class-visual-portfolio-pro.php' );
 		}
 
 		/**

--- a/classes/class-deactivate-duplicate-plugin.php
+++ b/classes/class-deactivate-duplicate-plugin.php
@@ -27,8 +27,11 @@ class Visual_Portfolio_Deactivate_Duplicate_Plugin {
 	 * First version of the free plugin that steps aside on its own when the Pro plugin
 	 * is active. Older ones declare the core class a second time instead, so they cannot
 	 * stay active next to it.
+	 *
+	 * `version_compare()` ranks a pre-release below the release it precedes, so the
+	 * `-alpha` suffix is what lets a beta or an RC of that version through.
 	 */
-	const FREE_PLUGIN_MIN_VERSION = '3.8.1';
+	const FREE_PLUGIN_MIN_VERSION = '3.8.1-alpha';
 
 	/**
 	 * Visual_Portfolio_Deactivate_Duplicate_Plugin constructor.
@@ -66,11 +69,19 @@ class Visual_Portfolio_Deactivate_Duplicate_Plugin {
 			return;
 		}
 
+		$free_plugin_file = WP_PLUGIN_DIR . '/' . self::FREE_PLUGIN;
+
+		// `active_plugins` keeps naming a plugin whose directory was removed by hand,
+		// and `get_plugin_data()` reads the file without checking that it is there.
+		if ( ! file_exists( $free_plugin_file ) ) {
+			return;
+		}
+
 		if ( ! function_exists( 'get_plugin_data' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$free_plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . self::FREE_PLUGIN, false, false );
+		$free_plugin_data = get_plugin_data( $free_plugin_file, false, false );
 
 		if (
 			empty( $free_plugin_data['Version'] ) ||

--- a/classes/class-deactivate-duplicate-plugin.php
+++ b/classes/class-deactivate-duplicate-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Checks if another version of Visual Portfolio/Visual Portfolio Pro is active and deactivates it.
+ * Deactivates a copy of Visual Portfolio that cannot run next to Visual Portfolio Pro.
  *
  * @package visual-portfolio/deactivate-duplicate-plugin
  */
@@ -14,66 +14,94 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Visual_Portfolio_Deactivate_Duplicate_Plugin {
 	/**
+	 * Basename of the free plugin.
+	 */
+	const FREE_PLUGIN = 'visual-portfolio/class-visual-portfolio.php';
+
+	/**
+	 * Basename of the Pro plugin.
+	 */
+	const PRO_PLUGIN = 'visual-portfolio-pro/class-visual-portfolio-pro.php';
+
+	/**
+	 * First version of the free plugin that steps aside on its own when the Pro plugin
+	 * is active. Older ones declare the core class a second time instead, so they cannot
+	 * stay active next to it.
+	 */
+	const FREE_PLUGIN_MIN_VERSION = '3.8.1';
+
+	/**
 	 * Visual_Portfolio_Deactivate_Duplicate_Plugin constructor.
 	 */
 	public function __construct() {
-		add_action( 'activated_plugin', array( $this, 'deactivate_other_instances' ) );
+		add_action( 'activated_plugin', array( $this, 'deactivate_outdated_free_plugin' ) );
 		add_action( 'pre_current_active_plugins', array( $this, 'plugin_deactivated_notice' ) );
 	}
 
 	/**
-	 * Checks if another version of Visual Portfolio/Visual Portfolio Pro is active and deactivates it.
-	 * Hooked on `activated_plugin` so other plugin is deactivated when current plugin is activated.
+	 * Deactivates the free plugin when the Pro plugin is active and the free copy is too
+	 * old to step aside by itself. Hooked on `activated_plugin`, so it runs whichever of
+	 * the two was just switched on.
 	 *
 	 * @param string $plugin The plugin being activated.
 	 */
-	public function deactivate_other_instances( $plugin ) {
-		if ( ! in_array( $plugin, array( 'visual-portfolio/class-visual-portfolio.php', 'visual-portfolio-pro/class-visual-portfolio-pro.php' ), true ) ) {
+	public function deactivate_outdated_free_plugin( $plugin ) {
+		if ( ! in_array( $plugin, array( self::FREE_PLUGIN, self::PRO_PLUGIN ), true ) ) {
 			return;
 		}
 
-		$plugin_to_deactivate  = 'visual-portfolio/class-visual-portfolio.php';
-		$deactivated_notice_id = 1;
+		$active_plugins = (array) get_option( 'active_plugins', array() );
 
-		// If we just activated the free version, deactivate the Pro version.
-		if ( $plugin === $plugin_to_deactivate ) {
-			$plugin_to_deactivate  = 'visual-portfolio-pro/class-visual-portfolio-pro.php';
-			$deactivated_notice_id = 2;
+		if ( is_multisite() ) {
+			$active_plugins = array_merge(
+				$active_plugins,
+				array_keys( (array) get_site_option( 'active_sitewide_plugins', array() ) )
+			);
 		}
 
-		if ( is_multisite() && is_network_admin() ) {
-			$active_plugins = (array) get_site_option( 'active_sitewide_plugins', array() );
-			$active_plugins = array_keys( $active_plugins );
-		} else {
-			$active_plugins = (array) get_option( 'active_plugins', array() );
+		if (
+			! in_array( self::FREE_PLUGIN, $active_plugins, true ) ||
+			! in_array( self::PRO_PLUGIN, $active_plugins, true )
+		) {
+			return;
 		}
 
-		foreach ( $active_plugins as $plugin_basename ) {
-			if ( $plugin_to_deactivate === $plugin_basename ) {
-				set_transient( 'vp_deactivated_notice_id', $deactivated_notice_id, 1 * HOUR_IN_SECONDS );
-				deactivate_plugins( $plugin_basename );
-				return;
-			}
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
+
+		$free_plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . self::FREE_PLUGIN, false, false );
+
+		if (
+			empty( $free_plugin_data['Version'] ) ||
+			version_compare( $free_plugin_data['Version'], self::FREE_PLUGIN_MIN_VERSION, '>=' )
+		) {
+			return;
+		}
+
+		set_transient( 'vp_deactivated_notice_id', 1, 1 * HOUR_IN_SECONDS );
+
+		deactivate_plugins( self::FREE_PLUGIN );
 	}
 
 	/**
-	 * Displays a notice when either Visual Portfolio or Visual Portfolio Pro is automatically deactivated.
+	 * Displays a notice when Visual Portfolio is automatically deactivated.
 	 */
 	public function plugin_deactivated_notice() {
-		$deactivated_notice_id = (int) get_transient( 'vp_deactivated_notice_id' );
-		if ( ! in_array( $deactivated_notice_id, array( 1, 2 ), true ) ) {
+		if ( 1 !== (int) get_transient( 'vp_deactivated_notice_id' ) ) {
 			return;
-		}
-
-		$message = __( "Visual Portfolio and Visual Portfolio Pro should not be active at the same time. We've automatically deactivated Visual Portfolio.", 'visual-portfolio' );
-		if ( 2 === $deactivated_notice_id ) {
-			$message = __( "Visual Portfolio and Visual Portfolio Pro should not be active at the same time. We've automatically deactivated Visual Portfolio Pro.", 'visual-portfolio' );
 		}
 
 		?>
 		<div class="notice notice-warning">
-			<p><?php echo esc_html( $message ); ?></p>
+			<p>
+				<?php
+				esc_html_e(
+					"This version of Visual Portfolio is too old to run next to Visual Portfolio Pro. We've automatically deactivated Visual Portfolio.",
+					'visual-portfolio'
+				);
+				?>
+			</p>
 		</div>
 		<?php
 


### PR DESCRIPTION
Visual Portfolio Pro ships this plugin's core inside `core-plugin/`, so the two declare the
same classes and only one of them may run. That was enforced by deactivating whichever of the
pair was not just activated, on top of an older `class_exists` guard that only holds while Pro
happens to be included first. Both can now stay activated instead: the standalone plugin reads
the active plugin list before it defines anything and returns when Pro is there, so none of its
own code loads.

The check reads the option rather than leaning on `class_exists` because the include order is
not ours to choose. WordPress includes network-activated plugins before site-activated ones,
and a third party can reorder `active_plugins`; in either case this plugin wins the race and
Pro ends up running its modules against a core it did not ship. Testing
`plugin_basename( __FILE__ )` is what separates the two roles this one file plays: the
standalone plugin's basename is in the list, the copy Pro bundles resolves to
`visual-portfolio-pro/core-plugin/…` and never is, so Pro keeps loading its own core. Copies
embedded in a theme or another plugin resolve outside the plugins directory and are likewise
unaffected.

**This has to ship as 3.8.1 or later.** `FREE_PLUGIN_MIN_VERSION` is the floor below which an
installed free copy is still deactivated, because those releases declare the core class a
second time instead of standing aside. Carrying this change in a release numbered below the
floor leaves it inert.

Deactivation is narrowed rather than removed, and it never touches Pro any more. Activating
this plugin next to Pro no longer switches Pro off; deactivating Pro is now the way back to the
free plugin.

Two cases it deliberately refuses to go quiet for. A Pro that WordPress will not load, since
`active_plugins` goes on naming a plugin whose directory was deleted by hand and the site would
be left with neither. And a Pro of 3.8.0 or older that has not loaded yet, because that release
reads an undefined `VISUAL_PORTFOLIO_VERSION` as an unsupported core and deactivates this
plugin from its own bootstrap, which on a network takes it off every site.

That bootstrap in Visual Portfolio Pro is untouched here and still deactivates this plugin on
every admin request, so nothing changes for Pro users until it is gated too. That edit and the
`core-plugin` submodule bump belong to the Pro repository's own pull request.

Checked in wp-env against a real Visual Portfolio Pro:

| Case | Result |
| --- | --- |
| Pro alone | core from `visual-portfolio-pro/core-plugin/…`, nothing from `visual-portfolio/` |
| Both, either include order | core from Pro, one file from `visual-portfolio/`: this one, which returns |
| Free alone | unchanged, 90 files, `vp_lists` registered |
| Free below the floor next to Pro | deactivated, notice shown |
| Pro named in `active_plugins`, directory gone | free loads |

One more thing landed here because the reversed load order is what exposes it.
`register_activation_hook( __FILE__, array( visual_portfolio(), 'activation_hook' ) )` builds
the instance while this file is still being included, so `init()` can run before Pro's own file
has, `is_pro()` answers no, and `pro_plugin_path` stays empty for the rest of the request. That
left `Visual_Portfolio_Templates` unable to resolve Pro template and style overrides. The lookup
now also runs on `plugins_loaded`.
