### PR TITLE
chore: ignore the dependency directories however they are linked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,15 +33,16 @@ build/**/*.hot-update.js.map
 build/Release
 
 # Composer directories. Anchored: an unanchored `vendor` also swallows
-# `assets/vendor/`, where the vendored front-end libraries live.
-/vendor/
+# `assets/vendor/`, where the vendored front-end libraries live. No trailing
+# slash, so the symlink a worktree puts here is ignored as well.
+/vendor
 
 # Custom PHPCS configs
 .phpcs.xml
 phpcs.xml
 
-# Dependency directories
-node_modules/
+# Dependency directories. No trailing slash, for the symlink case above.
+node_modules
 
 # Optional npm cache directory
 .npm
@@ -73,4 +74,5 @@ Thumbs.db
 
 # Local compatibility planning and automation artifacts
 .spec/
+.specs/
 output/


### PR DESCRIPTION
A pattern that ends in a slash matches directories only. In a `git worktree` checkout `vendor` and `node_modules` are symlinks into the main checkout, so git finds no directory under those names, and `git add -A` stages the two links — carrying the absolute path of the machine they were made on into a public repository.

Without the trailing slash both shapes are covered. `/vendor` keeps its anchor, so `assets/vendor/`, where the vendored front-end libraries live, stays tracked either way, and `node_modules` goes on matching at any depth.

Also ignores `.specs/`, next to the `.spec/` it sits beside.

Checked against a scratch repository carrying this `.gitignore`:

| case | result |
| --- | --- |
| `vendor`, `node_modules` as symlinks | ignored |
| `packages/foo/node_modules/dep.js` | ignored |
| `assets/vendor/fancybox/…` | still tracked |
| `.specs/plan.md` | ignored |