### PR TITLE
fix(lazyload): keep alt="" instead of a bare alt

### DIFF
--- a/classes/class-images.php
+++ b/classes/class-images.php
@@ -330,8 +330,10 @@ class Visual_Portfolio_Images {
 				if ( isset( $attributes[ $attr_name ] ) && $attr_value === $attributes[ $attr_name ] ) {
 					return true;
 				}
-			} elseif ( isset( $attributes[ $attr ] ) ) {
-				// Handle attribute name only (backward compatibility).
+			} elseif ( array_key_exists( $attr, $attributes ) ) {
+				// Handle attribute name only (backward compatibility). Skip markers are usually
+				// written without a value, `<img data-skip-lazy>`, and those carry `null`, which
+				// isset() reports as absent.
 				return true;
 			}
 		}
@@ -475,7 +477,7 @@ class Visual_Portfolio_Images {
 			$attributes['src'] = $placeholder;
 		}
 
-		if ( isset( $attributes['sizes'] ) ) {
+		if ( array_key_exists( 'sizes', $attributes ) ) {
 			unset( $attributes['sizes'] );
 		}
 
@@ -585,7 +587,11 @@ class Visual_Portfolio_Images {
 		$flattened_attributes = array();
 
 		foreach ( $attributes as $name => $attribute ) {
-			$flattened_attributes[ $name ] = $attribute['value'];
+			// `null` stands for an attribute written without a value, such as `<img srcset>`.
+			// An empty string stands for an attribute whose value is empty, such as `alt=""`,
+			// and the two have to stay apart: printing `alt=""` back as a bare `alt` is what
+			// makes crawlers report the image as having no alt text at all.
+			$flattened_attributes[ $name ] = 'y' === $attribute['vless'] ? null : $attribute['value'];
 		}
 
 		return $flattened_attributes;
@@ -594,7 +600,8 @@ class Visual_Portfolio_Images {
 	/**
 	 * Build attributes string.
 	 *
-	 * @param array $attributes Attributes.
+	 * @param array $attributes Attributes. A `null` value prints the attribute name on its own,
+	 *                          an empty string prints it as `name=""`.
 	 *
 	 * @return string
 	 */
@@ -602,7 +609,7 @@ class Visual_Portfolio_Images {
 		$string = array();
 
 		foreach ( $attributes as $name => $value ) {
-			if ( '' === $value ) {
+			if ( null === $value ) {
 				$string[] = sprintf( '%s', $name );
 			} else {
 				$string[] = sprintf( '%s="%s"', $name, esc_attr( $value ) );

--- a/tests/phpunit/unit/test-class-images.php
+++ b/tests/phpunit/unit/test-class-images.php
@@ -308,6 +308,18 @@ class ClassImages extends WP_UnitTestCase {
             ),
             'A valueless attribute must not gain an empty value'
         );
+
+        // A valueless `sizes` is still dropped, the same as one that carries a value.
+        $image_string = '<img src="image.jpg" alt="Test Image" width="10" height="10" sizes>';
+        $lazy_string  = '<img src="' . $placeholder . '" alt="Test Image" width="10" height="10" data-src="image.jpg" data-sizes="auto" loading="eager" class="vp-lazyload">';
+
+        $this->assertEquals(
+            $this->get_noscript_image( $image_string ) . $lazy_string,
+            Visual_Portfolio_Images::add_image_placeholders(
+                $image_string
+            ),
+            'A valueless sizes attribute must still be dropped'
+        );
     }
 
     /**

--- a/tests/phpunit/unit/test-class-images.php
+++ b/tests/phpunit/unit/test-class-images.php
@@ -145,7 +145,7 @@ class ClassImages extends WP_UnitTestCase {
         $this->assertTrue( is_int( $attach_id ) );
 
         $image_string = '<img width="150" height="150" src="' . esc_url( wp_get_attachment_image_url( $attach_id ) ) . '" class="wp-image-' . esc_attr( $attach_id ) . '" alt="" decoding="async" loading="lazy" />';
-        $lazy_string  = '<img width="150" height="150" src="' . $placeholder . '" class="wp-image-' . $attach_id  . ' vp-lazyload" alt decoding="async" loading="eager" data-src="' . esc_url( wp_get_attachment_image_url( $attach_id ) ) . '" data-sizes="auto">';
+        $lazy_string  = '<img width="150" height="150" src="' . $placeholder . '" class="wp-image-' . $attach_id  . ' vp-lazyload" alt="" decoding="async" loading="eager" data-src="' . esc_url( wp_get_attachment_image_url( $attach_id ) ) . '" data-sizes="auto">';
 
         $this->assertEquals(
             $this->get_noscript_image( $image_string ) . $lazy_string,
@@ -168,6 +168,16 @@ class ClassImages extends WP_UnitTestCase {
             Visual_Portfolio_Images::add_image_placeholders(
                 $image_string
             )
+        );
+
+        // Skip `data-no-lazy` written without a value, which is how most plugins mark an image.
+        $image_string = '<img src="image.jpg" alt="Test Image" width="10" height="10" data-no-lazy>';
+        $this->assertEquals(
+            $image_string,
+            Visual_Portfolio_Images::add_image_placeholders(
+                $image_string
+            ),
+            'A valueless skip marker must still skip the image'
         );
 
         // Skip `vp-lazyload` class name. Means - already lazy loaded.
@@ -258,6 +268,45 @@ class ClassImages extends WP_UnitTestCase {
                 $image_string
             ),
             'Images with data-no-lazy attribute (any value) should be skipped'
+        );
+    }
+
+    /**
+     * Empty attribute values have to survive the rewrite.
+     *
+     * `alt=""` is how a decorative image is marked. Printing it back as a bare `alt` is still
+     * valid HTML, but SEO crawlers look for the string `alt=` and report such images as having
+     * no alt text at all.
+     */
+    public function test_lazy_loading_keeps_empty_attribute_values() {
+        // Enable lazy load in settings.
+        Visual_Portfolio_Images::$allow_vp_lazyload = true;
+        Visual_Portfolio_Images::$allow_wp_lazyload = true;
+
+        $placeholder = Visual_Portfolio_Images::get_image_placeholder( 10, 10 );
+
+        // An empty value stays an empty value.
+        $image_string = '<img src="image.jpg" alt="" width="10" height="10">';
+        $lazy_string  = '<img src="' . $placeholder . '" alt="" width="10" height="10" data-src="image.jpg" data-sizes="auto" loading="eager" class="vp-lazyload">';
+
+        $this->assertEquals(
+            $this->get_noscript_image( $image_string ) . $lazy_string,
+            Visual_Portfolio_Images::add_image_placeholders(
+                $image_string
+            ),
+            'alt="" must not come back as a bare alt'
+        );
+
+        // An attribute written without a value stays without one.
+        $image_string = '<img src="image.jpg" alt="Test Image" width="10" height="10" data-custom>';
+        $lazy_string  = '<img src="' . $placeholder . '" alt="Test Image" width="10" height="10" data-custom data-src="image.jpg" data-sizes="auto" loading="eager" class="vp-lazyload">';
+
+        $this->assertEquals(
+            $this->get_noscript_image( $image_string ) . $lazy_string,
+            Visual_Portfolio_Images::add_image_placeholders(
+                $image_string
+            ),
+            'A valueless attribute must not gain an empty value'
         );
     }
 


### PR DESCRIPTION
The lazy-load rewriter rebuilds every image tag in post content from `wp_kses_hair()` output. It reduced each attribute to its value, so an attribute with an empty value and one written without a value both arrived as `''`, and the rebuild printed both as a bare name. An `alt=""` went in and an `alt` came out.

Browsers read a bare `alt` as an empty alt, so nothing looked wrong. SEO crawlers search for the literal string `alt=`. On visualportfolio.com that turned into 1289 of 1308 images reported as having no alt text, out of 4108 across 279 pages. The 19 real misses there are decorative backgrounds drawn by a different plugin.

The two cases are now distinct. An attribute written without a value carries `null`, taken from the `vless` flag `wp_kses_hair()` already returns and `flatten_kses_hair_data()` was discarding, and only `null` prints as a bare name.

**The part worth a second look is what that does to `isset()`.** It reports `null` as absent, and two checks relied on an empty string being present: the skip-marker match in `should_skip_image_with_blocked_attributes()` and the `sizes` removal. Skip markers are usually written without a value, `<img data-skip-lazy>`, so leaving that one as `isset()` would have made the rewriter lazy-load images another plugin had marked to leave alone. Both are `array_key_exists()` now, and a test pins the bare `data-no-lazy` case.

| Input attribute | Before | After |
| --- | --- | --- |
| `alt=""` | `alt` | `alt=""` |
| `srcset` with no value | `srcset` | `srcset` |
| `data-skip-lazy` with no value | image skipped | image skipped |

`build_attributes_string()` is public and its contract moved with it: `null` means valueless, `''` means empty value. Nothing in this repository or in Pro calls it outside `process_image()`, and a third party that passed `''` for a boolean attribute now gets `name=""`, which browsers treat the same way.

One existing expectation in `test-class-images.php` asserted `alt=""` coming back as a bare `alt`. It pinned the bug, so it moved with the fix rather than being made to pass.

**How to check.** Revert `classes/class-images.php`, keep the tests, and `npm run test:unit:php` fails twice, both times showing `alt` where `alt=""` belongs. With the fix: 286 tests and 1606 assertions pass, `npm run test:e2e` 104 pass, PHPCS and Biome clean.
